### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kodi-integration:
-    build: .
+    image: albator78/kodi-integration
     container_name: kodi-integration
     restart: unless-stopped
     network_mode: host  # Required for network discovery and magic packets
@@ -8,4 +8,4 @@ services:
       - UC_INTEGRATION_HTTP_PORT=9090
       - UC_CONFIG_HOME=/app/config
     volumes:
-      - ../config:/app/config
+      - ./config:/app/config


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to streamline the setup of the `kodi-integration` service by switching from a local build to a prebuilt image and adjusting the volume mapping for configuration files.

Key changes to the `docker-compose.yml` file:

* Changed the `kodi-integration` service to use the prebuilt Docker image `albator78/kodi-integration` instead of building locally.
* Updated the volume mapping for the `kodi-integration` service to use a relative path (`./config`) instead of a parent directory path (`../config`).Updated docker compose to use the actual image provided