### PR TITLE
Pr 21 : fix for browsing videos from favourites

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -72,11 +72,7 @@ class KodiConfigDevice:
     browsing_album_sort: str = field(default="album")
     browsing_files_sort: str = field(default="")
     browse_media_root: str = field(default="")
-    # Pinned shortcuts (favorites) added by the user from within the browse menu.
-    # Each entry: {"media_id": str, "media_type": str, "title": str,
-    #              "thumbnail": str | None, "broken": bool}
-    favorites: list = field(default_factory=list)
-    # Show favorites flat in the browse root in addition to the "Favorites" entry
+    # Show Kodi favourites flat in the browse root in addition to the "Favourites" entry
     favorites_in_root: bool = field(default=False)
 
     # pylint: disable=R0801

--- a/src/config.py
+++ b/src/config.py
@@ -72,6 +72,12 @@ class KodiConfigDevice:
     browsing_album_sort: str = field(default="album")
     browsing_files_sort: str = field(default="")
     browse_media_root: str = field(default="")
+    # Pinned shortcuts (favorites) added by the user from within the browse menu.
+    # Each entry: {"media_id": str, "media_type": str, "title": str,
+    #              "thumbnail": str | None, "broken": bool}
+    favorites: list = field(default_factory=list)
+    # Show favorites flat in the browse root in addition to the "Favorites" entry
+    favorites_in_root: bool = field(default=False)
 
     # pylint: disable=R0801
     def __post_init__(self):

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -164,7 +164,7 @@ def decode_toggle(media_id: str) -> dict | None:
     """Parse a toggle media_id into its components, or return None."""
     if not media_id or not media_id.startswith(FAVORITES_TOGGLE_PREFIX):
         return None
-    raw = media_id[len(FAVORITES_TOGGLE_PREFIX) :]
+    raw = media_id.removeprefix(FAVORITES_TOGGLE_PREFIX)
     parts = parse_qs(raw, keep_blank_values=True)
 
     def _first(key: str) -> str:

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -29,6 +29,6 @@ async def get_kodi_favourites(server: Any) -> list[dict]:
     try:
         result = await server.get_favourites()
         return result.get("favourites", [])
-    except Exception:
+    except Exception:  # pylint: disable=W0718
         _LOG.warning("Failed to fetch Kodi favourites", exc_info=True)
         return []

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -79,6 +79,7 @@ def add(
     media_type: str,
     title: str,
     thumbnail: str | None = None,
+    *,
     source: str | None = None,
 ) -> bool:
     """Add a favorite if not already present. Returns True if added."""

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -1,0 +1,183 @@
+"""
+Favorites (pinned shortcuts) helpers for the Kodi integration.
+
+Stores user-pinned directories/items in the per-device configuration so that
+the user can jump directly to a deep-linked location (e.g. a YouTube channel
+inside an addon, a Live TV channel, a sub-folder of a Source) from the
+browse-media root.
+
+:copyright: (c) 2026 by Albaintor
+:license: Mozilla Public License Version 2.0, see LICENSE for more details.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import parse_qs, quote, urlencode
+
+_LOG = logging.getLogger(__name__)
+
+# Media-id prefixes used to encode favorites-related actions in the browse tree.
+FAVORITES_ROOT = "kodi://favorites"
+FAVORITES_MANAGE = "kodi://favorites/manage"
+FAVORITES_TOGGLE_PREFIX = "kodi://favorites/toggle?"
+FAVORITES_CLEANUP = "kodi://favorites/cleanup"
+
+
+def normalize(entry: Any) -> dict | None:
+    """Coerce a stored favorite into a fully-populated dict (defensive).
+
+    Old configurations may contain entries missing some keys; we always
+    return a dict with the canonical keys or ``None`` if unusable.
+    """
+    if not isinstance(entry, dict):
+        return None
+    media_id = entry.get("media_id")
+    media_type = entry.get("media_type")
+    if not media_id or not media_type:
+        return None
+    return {
+        "media_id": str(media_id),
+        "media_type": str(media_type),
+        "title": str(entry.get("title") or media_id),
+        "thumbnail": entry.get("thumbnail") or None,
+        "broken": bool(entry.get("broken", False)),
+    }
+
+
+def list_favorites(raw: list | None) -> list[dict]:
+    """Return a sanitized list of favorite entries."""
+    if not raw:
+        return []
+    result: list[dict] = []
+    for item in raw:
+        norm = normalize(item)
+        if norm is not None:
+            result.append(norm)
+    return result
+
+
+def find_index(raw: list | None, media_id: str, media_type: str) -> int:
+    """Return the index of a favorite by (media_id, media_type) or -1."""
+    for idx, item in enumerate(list_favorites(raw)):
+        if item["media_id"] == media_id and item["media_type"] == media_type:
+            return idx
+    return -1
+
+
+def is_favorite(raw: list | None, media_id: str, media_type: str) -> bool:
+    """Return True if (media_id, media_type) is currently pinned."""
+    return find_index(raw, media_id, media_type) >= 0
+
+
+def add(raw: list, media_id: str, media_type: str, title: str, thumbnail: str | None = None) -> bool:
+    """Add a favorite if not already present. Returns True if added."""
+    if find_index(raw, media_id, media_type) >= 0:
+        return False
+    raw.append(
+        {
+            "media_id": media_id,
+            "media_type": media_type,
+            "title": title or media_id,
+            "thumbnail": thumbnail,
+            "broken": False,
+        }
+    )
+    return True
+
+
+def remove(raw: list, media_id: str, media_type: str) -> bool:
+    """Remove a favorite by (media_id, media_type). Returns True if removed."""
+    idx = find_index(raw, media_id, media_type)
+    if idx < 0:
+        return False
+    raw.pop(idx)
+    return True
+
+
+def remove_broken(raw: list) -> int:
+    """Remove all entries flagged as broken. Returns number removed."""
+    if not raw:
+        return 0
+    before = len(raw)
+    raw[:] = [it for it in list_favorites(raw) if not it.get("broken")]
+    return before - len(raw)
+
+
+def mark_broken(raw: list, media_id: str, media_type: str, broken: bool = True) -> bool:
+    """Flag (or unflag) a favorite as broken. Returns True if the flag changed."""
+    items = list_favorites(raw)
+    for idx, item in enumerate(items):
+        if item["media_id"] == media_id and item["media_type"] == media_type:
+            if bool(item.get("broken")) == broken:
+                return False
+            # Mutate in-place on the original list (which may contain partially populated entries).
+            raw[idx] = {**item, "broken": broken}
+            return True
+    return False
+
+
+def can_pin(media_id: str | None, media_type: str | None) -> bool:
+    """Return True if a directory/item is eligible to be pinned.
+
+    We deliberately limit pinning to URL-like targets that we know how to
+    re-open later from the favorites root: addon plugin:// paths, PVR
+    channel groups / channels, addon roots, and Kodi Sources sub-paths.
+    Library-only nodes (e.g. ``kodi://videos/all``) are NOT pinnable yet
+    because they are predefined entries.
+    """
+    # pylint: disable=R0911
+    if not media_id:
+        return False
+    if media_id.startswith(FAVORITES_ROOT):
+        return False
+    if media_id.startswith("plugin://"):
+        return True
+    # Allow PVR channel group sub-listings and the channel groups page.
+    if media_id.startswith("kodi://pvr/") and media_id != "kodi://pvr":
+        return True
+    # Allow Kodi Sources sub-paths (anything beneath kodi://sources/<root>).
+    if media_id.startswith("kodi://sources/") and media_id.count("/") > 3:
+        return True
+    # Allow individual PVR channels / addons / channel groups by media_type.
+    if media_type in ("channel", "channelgroup", "addon"):
+        return True
+    return False
+
+
+def encode_toggle(media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
+    """Build the special media_id used by the pin/unpin toggle item."""
+    qs = urlencode(
+        {
+            "id": media_id,
+            "type": media_type,
+            "title": title or media_id,
+            "parent": parent or "",
+        },
+        quote_via=quote,
+    )
+    return FAVORITES_TOGGLE_PREFIX + qs
+
+
+def decode_toggle(media_id: str) -> dict | None:
+    """Parse a toggle media_id into its components, or return None."""
+    if not media_id or not media_id.startswith(FAVORITES_TOGGLE_PREFIX):
+        return None
+    raw = media_id[len(FAVORITES_TOGGLE_PREFIX) :]
+    parts = parse_qs(raw, keep_blank_values=True)
+
+    def _first(key: str) -> str:
+        values = parts.get(key) or [""]
+        return values[0]
+
+    target_id = _first("id")
+    target_type = _first("type")
+    if not target_id or not target_type:
+        return None
+    return {
+        "media_id": target_id,
+        "media_type": target_type,
+        "title": _first("title") or target_id,
+        "parent": _first("parent") or None,
+    }

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -18,17 +18,81 @@ _LOG = logging.getLogger(__name__)
 # Media-id prefix for the virtual favourites browse root.
 FAVORITES_ROOT = "kodi://favorites"
 
+VALID_FAVOURITE_TYPES = frozenset({"media", "window", "script", "androidapp", "unknown"})
 
-async def get_kodi_favourites(server: Any) -> list[dict]:
+
+async def get_kodi_favourites(client: Any) -> list[dict]:
     """Fetch the current favourites list from Kodi.
 
     Uses the ``get_favourites`` wrapper on the Kodi client which calls
     ``Favourites.GetFavourites``.  Returns the favourites array or an
     empty list on error so the browse UI can degrade gracefully.
+
+    *client* must be a ``Kodi`` instance (i.e. ``device.client``), not the
+    raw ``jsonrpc_base.Server``.
     """
     try:
-        result = await server.get_favourites()
-        return result.get("favourites", [])
+        result = await client.get_favourites()
+        return _extract_favourites(result)
     except Exception:  # pylint: disable=W0718
-        _LOG.warning("Failed to fetch Kodi favourites", exc_info=True)
+        _LOG.debug("Failed to fetch Kodi favourites (method not available?)", exc_info=True)
         return []
+
+
+def _extract_favourites(result: Any) -> list[dict]:
+    """Validate and extract the favourites array from a GetFavourites result.
+
+    Returns the favourites list, or an empty list when the response is
+    malformed so callers can degrade gracefully.
+    """
+    if not isinstance(result, dict):
+        _LOG.debug("Favourites response: expected dict, got %s", type(result).__name__)
+        return []
+
+    favs = result.get("favourites")
+    if favs is None:
+        _LOG.debug("Favourites response missing 'favourites' key")
+        return []
+    if not isinstance(favs, list):
+        _LOG.debug("'favourites' must be an array, got %s", type(favs).__name__)
+        return []
+
+    limits = result.get("limits")
+    if limits is not None:
+        _validate_limits(limits)
+
+    clean: list[dict] = []
+    for idx, fav in enumerate(favs):
+        if _validate_favourite(fav, idx):
+            clean.append(fav)
+    return clean
+
+
+def _validate_favourite(fav: Any, index: int) -> bool:
+    """Validate a single Favourite.Details.Favourite entry. Returns True if usable."""
+    prefix = f"favourites[{index}]"
+    if not isinstance(fav, dict):
+        _LOG.debug("%s: expected object, got %s", prefix, type(fav).__name__)
+        return False
+
+    title = fav.get("title")
+    if not isinstance(title, str) or not title:
+        _LOG.debug("%s: missing or empty 'title'", prefix)
+        return False
+
+    fav_type = fav.get("type")
+    if fav_type not in VALID_FAVOURITE_TYPES:
+        _LOG.debug("%s: invalid type '%s'", prefix, fav_type)
+        return False
+
+    return True
+
+
+def _validate_limits(limits: Any) -> None:
+    """Log warnings for malformed List.LimitsReturned (non-fatal)."""
+    if not isinstance(limits, dict):
+        _LOG.debug("limits: expected object, got %s", type(limits).__name__)
+        return
+    total = limits.get("total")
+    if not isinstance(total, int) or total < 0:
+        _LOG.debug("limits: 'total' should be a non-negative int, got %r", total)

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -12,6 +12,7 @@ browse-media root.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any
 from urllib.parse import parse_qs, quote, urlencode
@@ -43,6 +44,7 @@ def normalize(entry: Any) -> dict | None:
         "title": str(entry.get("title") or media_id),
         "thumbnail": entry.get("thumbnail") or None,
         "broken": bool(entry.get("broken", False)),
+        "source": str(entry["source"]) if entry.get("source") else None,
     }
 
 
@@ -71,7 +73,14 @@ def is_favorite(raw: list | None, media_id: str, media_type: str) -> bool:
     return find_index(raw, media_id, media_type) >= 0
 
 
-def add(raw: list, media_id: str, media_type: str, title: str, thumbnail: str | None = None) -> bool:
+def add(
+    raw: list,
+    media_id: str,
+    media_type: str,
+    title: str,
+    thumbnail: str | None = None,
+    source: str | None = None,
+) -> bool:
     """Add a favorite if not already present. Returns True if added."""
     if find_index(raw, media_id, media_type) >= 0:
         return False
@@ -82,6 +91,7 @@ def add(raw: list, media_id: str, media_type: str, title: str, thumbnail: str | 
             "title": title or media_id,
             "thumbnail": thumbnail,
             "broken": False,
+            "source": source or None,
         }
     )
     return True
@@ -160,6 +170,17 @@ def encode_toggle(media_id: str, media_type: str, title: str, parent: str | None
     return FAVORITES_TOGGLE_PREFIX + qs
 
 
+def make_toggle_key(media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
+    """Build a compact deterministic key for long toggle payloads."""
+    raw = "\x1f".join([media_id or "", media_type or "", title or "", parent or ""])
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def encode_toggle_key(key: str) -> str:
+    """Build the special media_id used by compact pin/unpin toggle entries."""
+    return FAVORITES_TOGGLE_PREFIX + urlencode({"k": key}, quote_via=quote)
+
+
 def decode_toggle(media_id: str) -> dict | None:
     """Parse a toggle media_id into its components, or return None."""
     if not media_id or not media_id.startswith(FAVORITES_TOGGLE_PREFIX):
@@ -170,6 +191,10 @@ def decode_toggle(media_id: str) -> dict | None:
     def _first(key: str) -> str:
         values = parts.get(key) or [""]
         return values[0]
+
+    compact_key = _first("k")
+    if compact_key:
+        return {"key": compact_key}
 
     target_id = _first("id")
     target_type = _first("type")

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -1,10 +1,8 @@
 """
-Favorites (pinned shortcuts) helpers for the Kodi integration.
+Favorites helpers for the Kodi integration.
 
-Stores user-pinned directories/items in the per-device configuration so that
-the user can jump directly to a deep-linked location (e.g. a YouTube channel
-inside an addon, a Live TV channel, a sub-folder of a Source) from the
-browse-media root.
+Provides a thin wrapper around Kodi's ``Favourites.GetFavourites`` JSON-RPC
+endpoint so the media browser can display the user's Kodi-native favourites.
 
 :copyright: (c) 2026 by Albaintor
 :license: Mozilla Public License Version 2.0, see LICENSE for more details.
@@ -12,198 +10,25 @@ browse-media root.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from typing import Any
-from urllib.parse import parse_qs, quote, urlencode
 
 _LOG = logging.getLogger(__name__)
 
-# Media-id prefixes used to encode favorites-related actions in the browse tree.
+# Media-id prefix for the virtual favourites browse root.
 FAVORITES_ROOT = "kodi://favorites"
-FAVORITES_MANAGE = "kodi://favorites/manage"
-FAVORITES_TOGGLE_PREFIX = "kodi://favorites/toggle?"
-FAVORITES_CLEANUP = "kodi://favorites/cleanup"
 
 
-def normalize(entry: Any) -> dict | None:
-    """Coerce a stored favorite into a fully-populated dict (defensive).
+async def get_kodi_favourites(server: Any) -> list[dict]:
+    """Fetch the current favourites list from Kodi.
 
-    Old configurations may contain entries missing some keys; we always
-    return a dict with the canonical keys or ``None`` if unusable.
+    Uses the ``get_favourites`` wrapper on the Kodi client which calls
+    ``Favourites.GetFavourites``.  Returns the favourites array or an
+    empty list on error so the browse UI can degrade gracefully.
     """
-    if not isinstance(entry, dict):
-        return None
-    media_id = entry.get("media_id")
-    media_type = entry.get("media_type")
-    if not media_id or not media_type:
-        return None
-    return {
-        "media_id": str(media_id),
-        "media_type": str(media_type),
-        "title": str(entry.get("title") or media_id),
-        "thumbnail": entry.get("thumbnail") or None,
-        "broken": bool(entry.get("broken", False)),
-        "source": str(entry["source"]) if entry.get("source") else None,
-    }
-
-
-def list_favorites(raw: list | None) -> list[dict]:
-    """Return a sanitized list of favorite entries."""
-    if not raw:
+    try:
+        result = await server.get_favourites()
+        return result.get("favourites", [])
+    except Exception:
+        _LOG.warning("Failed to fetch Kodi favourites", exc_info=True)
         return []
-    result: list[dict] = []
-    for item in raw:
-        norm = normalize(item)
-        if norm is not None:
-            result.append(norm)
-    return result
-
-
-def find_index(raw: list | None, media_id: str, media_type: str) -> int:
-    """Return the index of a favorite by (media_id, media_type) or -1."""
-    for idx, item in enumerate(list_favorites(raw)):
-        if item["media_id"] == media_id and item["media_type"] == media_type:
-            return idx
-    return -1
-
-
-def is_favorite(raw: list | None, media_id: str, media_type: str) -> bool:
-    """Return True if (media_id, media_type) is currently pinned."""
-    return find_index(raw, media_id, media_type) >= 0
-
-
-def add(
-    raw: list,
-    media_id: str,
-    media_type: str,
-    title: str,
-    thumbnail: str | None = None,
-    *,
-    source: str | None = None,
-) -> bool:
-    """Add a favorite if not already present. Returns True if added."""
-    if find_index(raw, media_id, media_type) >= 0:
-        return False
-    raw.append(
-        {
-            "media_id": media_id,
-            "media_type": media_type,
-            "title": title or media_id,
-            "thumbnail": thumbnail,
-            "broken": False,
-            "source": source or None,
-        }
-    )
-    return True
-
-
-def remove(raw: list, media_id: str, media_type: str) -> bool:
-    """Remove a favorite by (media_id, media_type). Returns True if removed."""
-    idx = find_index(raw, media_id, media_type)
-    if idx < 0:
-        return False
-    raw.pop(idx)
-    return True
-
-
-def remove_broken(raw: list) -> int:
-    """Remove all entries flagged as broken. Returns number removed."""
-    if not raw:
-        return 0
-    before = len(raw)
-    raw[:] = [it for it in list_favorites(raw) if not it.get("broken")]
-    return before - len(raw)
-
-
-def mark_broken(raw: list, media_id: str, media_type: str, broken: bool = True) -> bool:
-    """Flag (or unflag) a favorite as broken. Returns True if the flag changed."""
-    items = list_favorites(raw)
-    for idx, item in enumerate(items):
-        if item["media_id"] == media_id and item["media_type"] == media_type:
-            if bool(item.get("broken")) == broken:
-                return False
-            # Mutate in-place on the original list (which may contain partially populated entries).
-            raw[idx] = {**item, "broken": broken}
-            return True
-    return False
-
-
-def can_pin(media_id: str | None, media_type: str | None) -> bool:
-    """Return True if a directory/item is eligible to be pinned.
-
-    We deliberately limit pinning to URL-like targets that we know how to
-    re-open later from the favorites root: addon plugin:// paths, PVR
-    channel groups / channels, addon roots, and Kodi Sources sub-paths.
-    Library-only nodes (e.g. ``kodi://videos/all``) are NOT pinnable yet
-    because they are predefined entries.
-    """
-    # pylint: disable=R0911
-    if not media_id:
-        return False
-    if media_id.startswith(FAVORITES_ROOT):
-        return False
-    if media_id.startswith("plugin://"):
-        return True
-    # Allow PVR channel group sub-listings and the channel groups page.
-    if media_id.startswith("kodi://pvr/") and media_id != "kodi://pvr":
-        return True
-    # Allow Kodi Sources sub-paths (anything beneath kodi://sources/<root>).
-    if media_id.startswith("kodi://sources/") and media_id.count("/") > 3:
-        return True
-    # Allow individual PVR channels / addons / channel groups by media_type.
-    if media_type in ("channel", "channelgroup", "addon"):
-        return True
-    return False
-
-
-def encode_toggle(media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
-    """Build the special media_id used by the pin/unpin toggle item."""
-    qs = urlencode(
-        {
-            "id": media_id,
-            "type": media_type,
-            "title": title or media_id,
-            "parent": parent or "",
-        },
-        quote_via=quote,
-    )
-    return FAVORITES_TOGGLE_PREFIX + qs
-
-
-def make_toggle_key(media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
-    """Build a compact deterministic key for long toggle payloads."""
-    raw = "\x1f".join([media_id or "", media_type or "", title or "", parent or ""])
-    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
-
-
-def encode_toggle_key(key: str) -> str:
-    """Build the special media_id used by compact pin/unpin toggle entries."""
-    return FAVORITES_TOGGLE_PREFIX + urlencode({"k": key}, quote_via=quote)
-
-
-def decode_toggle(media_id: str) -> dict | None:
-    """Parse a toggle media_id into its components, or return None."""
-    if not media_id or not media_id.startswith(FAVORITES_TOGGLE_PREFIX):
-        return None
-    raw = media_id.removeprefix(FAVORITES_TOGGLE_PREFIX)
-    parts = parse_qs(raw, keep_blank_values=True)
-
-    def _first(key: str) -> str:
-        values = parts.get(key) or [""]
-        return values[0]
-
-    compact_key = _first("k")
-    if compact_key:
-        return {"key": compact_key}
-
-    target_id = _first("id")
-    target_type = _first("type")
-    if not target_id or not target_type:
-        return None
-    return {
-        "media_id": target_id,
-        "media_type": target_type,
-        "title": _first("title") or target_id,
-        "parent": _first("parent") or None,
-    }

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -2114,8 +2114,12 @@ class KodiDevice(IKodiDevice):
         if self._kodi is None:
             return None
         results = await self._kodi.add_favourites(
-            title, fav_type=fav_type, path=path, window=window,
-            windowparameter=windowparameter, thumbnail=thumbnail,
+            title,
+            fav_type=fav_type,
+            path=path,
+            window=window,
+            windowparameter=windowparameter,
+            thumbnail=thumbnail,
         )
         _LOG.debug("[%s] Add favourite %s (%s) : %s", self.device_config.address, title, path, results)
         return results

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -599,9 +599,10 @@ class KodiDevice(IKodiDevice):
 
         :returns: True if device is connected or if the connection retries has not reached it limit
         """
-        if not self._kodi_connection.connected and self._reconnect_retry >= CONNECTION_RETRIES:
+        connection = self._kodi_connection
+        if (connection is None or not connection.connected) and self._reconnect_retry >= CONNECTION_RETRIES:
             return False
-        if self._kodi_connection is None or not self._kodi_connection.connected:
+        if connection is None or not connection.connected:
             self._reconnect_retry += 1
             self._available = False
             _LOG.debug(

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -2103,7 +2103,8 @@ class KodiDevice(IKodiDevice):
     async def add_favourites(
         self,
         title: str,
-        type: Literal["media", "window", "script", "androidapp", "unknown"],
+        *,
+        fav_type: Literal["media", "window", "script", "androidapp", "unknown"],
         path: str | None = None,
         window: str | None = None,
         windowparameter: str | None = None,
@@ -2112,6 +2113,6 @@ class KodiDevice(IKodiDevice):
         """Add a new item to the favourite menu."""
         if self._kodi is None:
             return None
-        results = await self._kodi.add_favourites(title, type, path, window, windowparameter, thumbnail)
+        results = await self._kodi.add_favourites(title, fav_type=fav_type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail)
         _LOG.debug("[%s] Add favourite %s (%s) : %s", self.device_config.address, title, path, results)
         return results

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -2113,6 +2113,9 @@ class KodiDevice(IKodiDevice):
         """Add a new item to the favourite menu."""
         if self._kodi is None:
             return None
-        results = await self._kodi.add_favourites(title, fav_type=fav_type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail)
+        results = await self._kodi.add_favourites(
+            title, fav_type=fav_type, path=path, window=window,
+            windowparameter=windowparameter, thumbnail=thumbnail,
+        )
         _LOG.debug("[%s] Add favourite %s (%s) : %s", self.device_config.address, title, path, results)
         return results

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -1987,7 +1987,7 @@ class KodiDevice(IKodiDevice):
     async def play_media(self, params: dict[str, Any]):
         """Play media."""
         _LOG.debug("[%s] Play media %s", self.device_config.address, params)
-        await self.media_browser.play_media(params)
+        return await self.media_browser.play_media(params)
 
     @retry()
     async def clear_playlist(self):

--- a/src/kodi_device.py
+++ b/src/kodi_device.py
@@ -2091,3 +2091,27 @@ class KodiDevice(IKodiDevice):
                 exc,
             )
         return None
+
+    async def get_favourites(self) -> list[dict[str, Any]]:
+        """Return the user favourites."""
+        if self._kodi is None:
+            return []
+        results = await self._kodi.get_favourites()
+        _LOG.debug("[%s] Extract favourites %s", self.device_config.address, results)
+        return results
+
+    async def add_favourites(
+        self,
+        title: str,
+        type: Literal["media", "window", "script", "androidapp", "unknown"],
+        path: str | None = None,
+        window: str | None = None,
+        windowparameter: str | None = None,
+        thumbnail: str | None = None,
+    ) -> str | None:
+        """Add a new item to the favourite menu."""
+        if self._kodi is None:
+            return None
+        results = await self._kodi.add_favourites(title, type, path, window, windowparameter, thumbnail)
+        _LOG.debug("[%s] Add favourite %s (%s) : %s", self.device_config.address, title, path, results)
+        return results

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -529,6 +529,41 @@ class MediaBrowser:
         )
         return result
 
+    async def _handle_favorites_play_toggle(self, media_id: str) -> None:
+        """Process a favorites toggle triggered via play_media.
+
+        Adds or removes a favorite silently.  No browse response is returned
+        because the remote stays on the current screen (play_media does not
+        push a navigation level).
+        """
+        params = self._resolve_toggle_params(media_id)
+        if not params:
+            return
+        cfg = self._device.device_config
+        if cfg.favorites is None:
+            cfg.favorites = []
+        _LOG.debug(
+            "[%s] Favorites play toggle: action=%s target=%s type=%s",
+            self._device.device_config.address,
+            "remove" if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]) else "add",
+            params["media_id"],
+            params["media_type"],
+        )
+        changed = False
+        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
+            changed = favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
+        else:
+            source = self._get_source_label(params["media_id"], params["media_type"])
+            changed = favorites.add(
+                cfg.favorites,
+                params["media_id"],
+                params["media_type"],
+                params.get("title") or params["media_id"],
+                source=source,
+            )
+        if changed:
+            self._persist_favorites()
+
     def _handle_favorites_cleanup(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
         """Remove all broken favorites."""
         cfg = self._device.device_config
@@ -545,19 +580,19 @@ class MediaBrowser:
         """Build the pin/unpin entry."""
         pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
         label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
-        # After pin/unpin, stay in the current directory by re-browsing it.
-        # This avoids stale back-navigation levels on the remote since the
-        # toggle response replaces the current screen with the same view.
-        parent = media_id
-        toggle_id = self._build_toggle_media_id(media_id, media_type, title, parent=parent)
+        # Use can_play so the remote sends a play_media command instead of
+        # browse_media.  This avoids pushing a new navigation level and the
+        # stale back-entry that comes with it.  The play_media handler in
+        # MediaBrowser intercepts the toggle URL and silently updates the
+        # favorites list.
+        toggle_id = self._build_toggle_media_id(media_id, media_type, title, parent=media_id)
         return BrowseMediaItem(
             title=self.get_localized(label_key),
             media_id=toggle_id,
             media_class=MediaClass.DIRECTORY,
             media_type=MediaContentType.URL.value,
-            can_browse=True,
-            can_play=False,
-            items=[],
+            can_browse=False,
+            can_play=True,
         )
 
     def _maybe_inject_pin_item(self, item: BrowseMediaItem, media_id: str | None, media_type: str | None) -> None:
@@ -1904,6 +1939,12 @@ class MediaBrowser:
         item: dict[str, Any] = {}
         if media_id is None or media_type is None:
             return StatusCodes.BAD_REQUEST
+        # Intercept favorites toggle URLs: the pin/unpin button uses
+        # can_play so the remote sends play_media instead of browse_media,
+        # avoiding a stale back-navigation level.
+        if media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX):
+            await self._handle_favorites_play_toggle(media_id)
+            return StatusCodes.OK
         if media_type == "channel":
             if media_id.startswith("kodi://"):
                 media_id = media_id.rstrip("/").rsplit("/", 1)[-1]

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -42,6 +42,7 @@ _LOG = logging.getLogger(__name__)
 # the construction sites or the BrowseMediaItem constructor raises
 # ValueError mid-loop and aborts the whole listing.
 MAX_MEDIA_ID_LEN = 255
+MAX_ROOT_FAVORITES = 10
 
 
 MEDIA_CONTENT_LABELS = {
@@ -147,6 +148,12 @@ class MediaBrowser:
         self._pvr_available: bool | None = None
         self._addons_video_available: bool | None = None
         self._addons_audio_available: bool | None = None
+        # Runtime cache for compact favorites toggle actions. Needed when the
+        # original media_id is too long to fit in ucapi's 255-char media_id cap.
+        self._favorites_toggle_cache: dict[str, dict[str, str]] = {}
+        # Remember browse entry titles by media_id so deep plugin:// navigation
+        # and favorites can show a human-readable label instead of raw URLs.
+        self._browse_title_cache: dict[str, str] = {}
 
     async def _is_pvr_available(self) -> bool:
         """Return True if Kodi has at least one PVR channel group (TV or Radio)."""
@@ -161,7 +168,10 @@ class MediaBrowser:
             self._pvr_available = False
         # pylint: disable=W0718
         except Exception:
-            self._pvr_available = False
+            # Fail-open on transient connection errors so root entries remain
+            # visible and recover automatically once Kodi is reachable again.
+            self._pvr_available = None
+            return True
         return self._pvr_available
 
     async def _is_addons_available(self, content: str) -> bool:
@@ -177,7 +187,9 @@ class MediaBrowser:
             available = bool((result or {}).get("addons"))
         # pylint: disable=W0718
         except Exception:
-            available = False
+            # Fail-open on transient connection errors so root entries remain
+            # visible and recover automatically once Kodi is reachable again.
+            return True
         setattr(self, cache_attr, available)
         return available
 
@@ -218,6 +230,95 @@ class MediaBrowser:
                 ex,
             )
 
+    def _build_toggle_media_id(self, media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
+        """Build a toggle media_id and transparently fall back to compact mode.
+
+        ucapi caps media_id to 255 chars. For long plugin paths, we keep the
+        real payload in an in-memory cache and expose only a short key.
+        """
+        toggle_id = favorites.encode_toggle(media_id, media_type, title, parent=parent)
+        if len(toggle_id) <= MAX_MEDIA_ID_LEN:
+            return toggle_id
+        key = favorites.make_toggle_key(media_id, media_type, title, parent=parent)
+        if len(self._favorites_toggle_cache) >= 2048:
+            self._favorites_toggle_cache.clear()
+        self._favorites_toggle_cache[key] = {
+            "media_id": media_id,
+            "media_type": media_type,
+            "title": title or media_id,
+            "parent": parent or "",
+        }
+        return favorites.encode_toggle_key(key)
+
+    def _remember_browse_title(self, media_id: str | None, title: str | None) -> None:
+        """Remember a browse title for later lookups."""
+        if not media_id or not title:
+            return
+        cleaned = strip_kodi_formatting(title).strip()
+        if not cleaned:
+            return
+        if len(self._browse_title_cache) >= 4096:
+            self._browse_title_cache.clear()
+        self._browse_title_cache[media_id] = cleaned
+
+    def _get_cached_title(self, media_id: str, default: str | None = None) -> str:
+        """Return cached title for media_id, falling back to default/raw id."""
+        cached = self._browse_title_cache.get(media_id)
+        if cached:
+            return cached
+        return default or media_id
+
+    def _get_source_label(self, media_id: str, media_type: str) -> str | None:
+        """Derive a human-readable source/addon label for a pinnable item.
+
+        For plugin:// addons: looks up the addon root title from the browse
+        cache (populated when the user browses the addons list).
+        For PVR / sources items: returns a fixed label.
+        Returns None when no label is available (no API call is made).
+        """
+        if media_id.startswith("plugin://"):
+            # plugin://plugin.video.twitch/following/... -> plugin.video.twitch
+            parts = media_id.split("/")
+            if len(parts) >= 3 and parts[2]:
+                addon_id = parts[2]
+                label = self._browse_title_cache.get(f"plugin://{addon_id}/")
+                if label:
+                    return label
+                # Fallback: titlecase the last segment of the addon_id
+                # e.g. "plugin.video.twitch" -> "Twitch"
+                segments = addon_id.split(".")
+                if segments:
+                    return segments[-1].capitalize()
+            return None
+        if media_id.startswith("kodi://pvr") or media_type in ("channel", "channelgroup"):
+            return self.get_localized("Live TV")
+        if media_id.startswith("kodi://sources"):
+            return self.get_localized("Sources")
+        return None
+
+    def _resolve_toggle_params(self, media_id: str) -> dict[str, str] | None:
+        """Resolve a favorites toggle media_id (direct payload or compact key)."""
+        params = favorites.decode_toggle(media_id)
+        if not params:
+            return None
+        key = params.get("key")
+        if not key:
+            return {
+                "media_id": str(params["media_id"]),
+                "media_type": str(params["media_type"]),
+                "title": str(params.get("title") or params["media_id"]),
+                "parent": str(params.get("parent") or ""),
+            }
+        cached = self._favorites_toggle_cache.get(str(key))
+        if not cached:
+            return None
+        return {
+            "media_id": str(cached.get("media_id") or ""),
+            "media_type": str(cached.get("media_type") or ""),
+            "title": str(cached.get("title") or cached.get("media_id") or ""),
+            "parent": str(cached.get("parent") or ""),
+        }
+
     def _favorite_item(self, fav: dict, *, with_unpin: bool = False) -> BrowseMediaItem | None:
         """Render a saved favorite as a BrowseMediaItem.
 
@@ -231,19 +332,17 @@ class MediaBrowser:
         title = fav.get("title") or fav.get("media_id", "")
         if fav.get("broken"):
             title = f"⚠ {title}"
+        source: str | None = fav.get("source") or None
         if with_unpin:
-            toggle_id = favorites.encode_toggle(
-                fav["media_id"], fav["media_type"], fav.get("title", title), favorites.FAVORITES_MANAGE
+            toggle_id = self._build_toggle_media_id(
+                fav["media_id"],
+                fav["media_type"],
+                fav.get("title", title),
+                favorites.FAVORITES_MANAGE,
             )
-            if len(toggle_id) > MAX_MEDIA_ID_LEN:
-                _LOG.warning(
-                    "Skipping unpin item, toggle media_id exceeds %d chars for %s",
-                    MAX_MEDIA_ID_LEN,
-                    str(fav.get("media_id", ""))[:120],
-                )
-                return None
             return BrowseMediaItem(
                 title=self.get_localized("Unpin") + ": " + title,
+                subtitle=source,
                 media_id=toggle_id,
                 media_class=MediaClass.DIRECTORY,
                 media_type=MediaContentType.URL.value,
@@ -268,6 +367,7 @@ class MediaBrowser:
         can_play = media_type in ("channel",) or media_id.startswith("plugin://") and "?" in media_id
         return BrowseMediaItem(
             title=title,
+            subtitle=source,
             media_id=media_id,
             media_class=MediaClass.DIRECTORY,
             media_type=media_type,
@@ -342,29 +442,84 @@ class MediaBrowser:
         paging.count = 1
         return item, paging
 
-    def _handle_favorites_toggle(
+    async def _handle_favorites_toggle(
         self, media_id: str, paging: PaginationOptions
     ) -> tuple[BrowseMediaItem, PaginationOptions]:
         """Add or remove a favorite based on a toggle media_id."""
-        params = favorites.decode_toggle(media_id)
+        params = self._resolve_toggle_params(media_id)
         if not params:
             return self._build_confirmation(self.get_localized("Invalid favorite"), favorites.FAVORITES_ROOT, paging)
         cfg = self._device.device_config
         if cfg.favorites is None:
             cfg.favorites = []
         parent = params.get("parent") or favorites.FAVORITES_ROOT
-        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
-            favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
-            self._persist_favorites()
-            return self._build_confirmation(self.get_localized("Unpinned"), parent, paging)
-        favorites.add(
-            cfg.favorites,
+        changed = False
+        action = "remove" if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]) else "add"
+        _LOG.debug(
+            "[%s] Favorites toggle request: action=%s target=%s type=%s parent=%s",
+            self._device.device_config.address,
+            action,
             params["media_id"],
             params["media_type"],
-            params.get("title") or params["media_id"],
+            parent,
         )
-        self._persist_favorites()
-        return self._build_confirmation(self.get_localized("Pinned"), parent, paging)
+        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
+            changed = favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
+        else:
+            source = self._get_source_label(params["media_id"], params["media_type"])
+            changed = favorites.add(
+                cfg.favorites,
+                params["media_id"],
+                params["media_type"],
+                params.get("title") or params["media_id"],
+                source=source,
+            )
+        if changed:
+            self._persist_favorites()
+
+        # Stay in context: return the same logical view the user was at so the
+        # toggle response replaces the current screen.  The hardware Back button
+        # on the remote may still show a stale cached level below – this is a
+        # remote firmware limitation that cannot be solved server-side.
+        if parent == favorites.FAVORITES_ROOT:
+            result = self._build_favorites_root(paging)
+            _LOG.debug(
+                "[%s] Favorites toggle response: view=%s title=%s items=%s",
+                self._device.device_config.address,
+                result[0].media_id,
+                result[0].title,
+                len(result[0].items or []),
+            )
+            return result
+        if parent == favorites.FAVORITES_MANAGE:
+            result = self._build_favorites_manage(paging)
+            _LOG.debug(
+                "[%s] Favorites toggle response: view=%s title=%s items=%s",
+                self._device.device_config.address,
+                result[0].media_id,
+                result[0].title,
+                len(result[0].items or []),
+            )
+            return result
+        refreshed = await self.browse_media(parent, params.get("media_type"), paging)
+        if refreshed is not None:
+            _LOG.debug(
+                "[%s] Favorites toggle response: view=%s title=%s items=%s",
+                self._device.device_config.address,
+                refreshed[0].media_id,
+                refreshed[0].title,
+                len(refreshed[0].items or []),
+            )
+            return refreshed
+        result = self._build_confirmation(self.get_localized("Pinned"), parent, paging)
+        _LOG.debug(
+            "[%s] Favorites toggle response: view=%s title=%s items=%s",
+            self._device.device_config.address,
+            result[0].media_id,
+            result[0].title,
+            len(result[0].items or []),
+        )
+        return result
 
     def _handle_favorites_cleanup(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
         """Remove all broken favorites."""
@@ -379,18 +534,14 @@ class MediaBrowser:
         )
 
     def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem | None:
-        """Build the pin/unpin entry. Returns None when the toggle URL would exceed 255 chars."""
+        """Build the pin/unpin entry."""
         pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
         label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
-        toggle_id = favorites.encode_toggle(media_id, media_type, title, parent=media_id)
-        if len(toggle_id) > MAX_MEDIA_ID_LEN:
-            _LOG.debug(
-                "Skipping pin item, toggle media_id would exceed %d chars (%d) for %s",
-                MAX_MEDIA_ID_LEN,
-                len(toggle_id),
-                media_id[:120],
-            )
-            return None
+        # UX workaround: after pin/unpin from deep folder views, jump back to
+        # Home so users immediately see updated root favorites and don't need
+        # to back out through the whole navigation path.
+        parent = "kodi://"
+        toggle_id = self._build_toggle_media_id(media_id, media_type, title, parent=parent)
         return BrowseMediaItem(
             title=self.get_localized(label_key),
             media_id=toggle_id,
@@ -481,7 +632,7 @@ class MediaBrowser:
             return None
         label = strip_kodi_formatting(file.get("label", ""))
         if file.get("filetype", "directory") == "directory":
-            return BrowseMediaItem(
+            item = BrowseMediaItem(
                 title=label,
                 media_id=media_id,
                 media_class=MediaClass.DIRECTORY,
@@ -491,13 +642,15 @@ class MediaBrowser:
                 can_search=True,
                 items=[],
             )
+            self._remember_browse_title(media_id, label)
+            return item
         if extract_thumbnail:
             thumbnail: str = file.get("file")
             if thumbnail:
                 thumbnail = self._device.client.get_thumbnail_from_file(thumbnail.rstrip("/"))
         else:
             thumbnail: str | None = None
-        return BrowseMediaItem(
+        item = BrowseMediaItem(
             title=label,
             media_id=media_id,
             media_class=MediaClass.VIDEO,
@@ -508,6 +661,8 @@ class MediaBrowser:
             thumbnail=thumbnail,
             items=[],
         )
+        self._remember_browse_title(media_id, label)
+        return item
 
     def get_artwork_url(self, url: str) -> str | None:
         """Return artwork url."""
@@ -758,7 +913,7 @@ class MediaBrowser:
     def get_item_from_channel_group(self, group: dict[str, Any], parent_id: str) -> BrowseMediaItem:
         """Build item from a PVR channel group."""
         media_id = f"{parent_id}/{int(group.get('channelgroupid', 0))}"
-        return BrowseMediaItem(
+        item = BrowseMediaItem(
             title=group.get("label", ""),
             media_id=media_id,
             media_class=MediaClass.DIRECTORY,
@@ -767,6 +922,8 @@ class MediaBrowser:
             can_search=False,
             items=[],
         )
+        self._remember_browse_title(media_id, group.get("label", ""))
+        return item
 
     def get_item_from_channel(self, channel: dict[str, Any]) -> BrowseMediaItem:
         """Build item from a PVR channel (live TV / radio)."""
@@ -805,17 +962,21 @@ class MediaBrowser:
             if len(subtitle) > 255:
                 subtitle = subtitle[:252].rstrip() + "..."
         addon_id = str(addon.get("addonid", ""))
-        return BrowseMediaItem(
-            title=strip_kodi_formatting(addon.get("name")) or addon_id,
+        title = strip_kodi_formatting(addon.get("name")) or addon_id
+        media_id = f"plugin://{addon_id}/" if addon_id else ""
+        item = BrowseMediaItem(
+            title=title,
             subtitle=subtitle,
             # Addons are browsed via Kodi's virtual file system: plugin://<addonid>/
-            media_id=f"plugin://{addon_id}/" if addon_id else "",
+            media_id=media_id,
             media_class=MediaClass.APP if hasattr(MediaClass, "APP") else MediaClass.DIRECTORY,
             media_type="addondir",
             can_play=False,
             can_browse=True,
             thumbnail=thumbnail,
         )
+        self._remember_browse_title(media_id, title)
+        return item
 
     @staticmethod
     def get_sorting(sorting: str) -> dict[str, str]:
@@ -831,6 +992,28 @@ class MediaBrowser:
         found = [x.get_media_item() for x in self._library_items if x.media_id == media_id]
         if len(found) > 0:
             return found[0]
+        return None
+
+    async def _get_channel_group_title(self, parent_id: str | None, group_id: str) -> str | None:
+        """Resolve the display title for a PVR channel group."""
+        if not parent_id:
+            return None
+        parent = parent_id.rstrip("/")
+        if not parent.startswith("kodi://pvr/"):
+            return None
+        channel_type = parent.rsplit("/", 1)[-1]
+        if channel_type not in ("tv", "radio"):
+            return None
+        try:
+            data = await self._device.server.PVR.GetChannelGroups(channeltype=channel_type)
+        # pylint: disable=W0718
+        except Exception:
+            return None
+        for group in (data or {}).get("channelgroups", []):
+            if str(group.get("channelgroupid", "")) == str(group_id):
+                label = group.get("label")
+                if label:
+                    return str(label)
         return None
 
     async def add_now_playing_item(self, items: list[BrowseMediaItem], position: int):
@@ -882,6 +1065,19 @@ class MediaBrowser:
             else:
                 paging = PaginationOptions(page=paging.page, limit=paging.limit, count=0)
 
+            if media_id and (
+                media_id.startswith(favorites.FAVORITES_ROOT)
+                or media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX)
+            ):
+                _LOG.debug(
+                    "[%s] Browse request: media_id=%s media_type=%s page=%s limit=%s",
+                    self._device.device_config.address,
+                    media_id,
+                    media_type,
+                    paging.page,
+                    paging.limit,
+                )
+
             # Change media_id if empty (root) and a custom category has been defined by user
             # add_now_playing = False
             if (media_id is None or media_id == "") and self._device.device_config.browse_media_root != "":
@@ -904,10 +1100,36 @@ class MediaBrowser:
                 # Optionally inject favorites flat into the browse root
                 if getattr(self._device.device_config, "favorites_in_root", False):
                     favs = favorites.list_favorites(self._device.device_config.favorites)
-                    for fav in favs:
+                    root_favorites: list[BrowseMediaItem] = []
+                    has_more_favorites = len(favs) > MAX_ROOT_FAVORITES
+                    visible_favorites = (
+                        favs[: MAX_ROOT_FAVORITES - 1] if has_more_favorites else favs[:MAX_ROOT_FAVORITES]
+                    )
+                    for fav in visible_favorites:
                         entry = self._favorite_item(fav)
                         if entry is not None:
-                            items.insert(0, entry)
+                            root_favorites.append(entry)
+
+                    if has_more_favorites:
+                        # Show first N-1 favorites directly and keep slot N as
+                        # a link to the full favorites view for the overflow.
+                        root_favorites.append(
+                            BrowseMediaItem(
+                                title=self.get_localized("Favorites"),
+                                media_id=favorites.FAVORITES_ROOT,
+                                media_class=MediaClass.DIRECTORY,
+                                media_type=MediaContentType.URL.value,
+                                can_browse=True,
+                                can_play=False,
+                                items=[],
+                            )
+                        )
+                        # Avoid duplicate favorites root entry when the
+                        # overflow link is already injected in the top section.
+                        items = [x for x in items if x.media_id != favorites.FAVORITES_ROOT]
+
+                    for entry in reversed(root_favorites):
+                        items.insert(0, entry)
                 paging.count = len(items)
                 item.title = self.get_localized(item.title)
                 item.items = items
@@ -919,7 +1141,7 @@ class MediaBrowser:
             if media_id == favorites.FAVORITES_MANAGE:
                 return self._build_favorites_manage(paging)
             if media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX):
-                return self._handle_favorites_toggle(media_id, paging)
+                return await self._handle_favorites_toggle(media_id, paging)
             if media_id == favorites.FAVORITES_CLEANUP:
                 return self._handle_favorites_cleanup(paging)
             # ----------------------------------------------
@@ -1105,7 +1327,8 @@ class MediaBrowser:
                 # Browsing inside a Kodi addon (plugin://...) - works like a Source
                 if media_type == "addondir" or media_id.startswith("plugin://"):
                     item = self.get_root_item()
-                    item.title = media_id
+                    item.media_id = media_id
+                    item.title = self._get_cached_title(media_id, media_id)
                     limit = paging.limit
                     end = paging.page * limit
                     arguments = {
@@ -1160,10 +1383,12 @@ class MediaBrowser:
                     # Inject the pin/unpin shortcut at the top so the user can
                     # bookmark this exact location.
                     self._maybe_inject_pin_item(item, media_id, media_type or "addondir")
+                    self._remember_browse_title(media_id, item.title)
                     return item, paging
                 if media_type.startswith("kodi://sources"):
                     back_buttons = 0
                     item = self.get_root_item()
+                    item.media_id = media_id
                     if not media_id.startswith("multipath://"):
                         item.title = media_id
                     limit = paging.limit
@@ -1557,6 +1782,8 @@ class MediaBrowser:
                         paging.count = paging.count + 1
                     for channel in channels.get("channels", []):
                         item.items.append(self.get_item_from_channel(channel))
+                    if resolved_title := await self._get_channel_group_title(parent_id, real_media_id):
+                        item.title = resolved_title
                     # Allow pinning of the whole channel group
                     self._maybe_inject_pin_item(item, media_id, "channelgroup")
                 elif media_type == MediaContentType.PLAYLIST.value:
@@ -1606,6 +1833,11 @@ class MediaBrowser:
                         media_id,
                     )
                     return None
+                # Dynamic browse branches often start from get_root_item(), which
+                # defaults to media_id="library". Return the actual browsed id so
+                # the remote can correlate the response with the current view.
+                if media_id and item.media_id == "library":
+                    item.media_id = media_id
                 return item, paging
         # pylint: disable = W0718
         except Exception as ex:

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -1074,14 +1074,39 @@ class MediaBrowser:
                                 self._persist_favorites()
                             item.items.append(self._make_pin_item(media_id, media_type or "addondir", media_id))
                     if data:
+                        skipped = 0
                         for file in data.get("files", []) or []:
-                            sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
-                            # Re-attach thumbnail from JSON-RPC response if present
-                            thumb = file.get("thumbnail") or (file.get("art") or {}).get("thumb")
-                            if thumb:
-                                sub.thumbnail = self.get_artwork_url(thumb)
-                            item.items.append(sub)
-                        paging.count = data.get("limits", {}).get("total", len(item.items))
+                            file_id = file.get("file", "") or ""
+                            # ucapi caps media_id at 255 chars; some Kodi addons
+                            # (e.g. Twitch followed channels) emit longer URLs.
+                            # Skip those entries instead of aborting the whole
+                            # listing so the user still sees the rest.
+                            if len(file_id) > 255:
+                                _LOG.warning(
+                                    "[%s] Skipping addon entry with media_id > 255 chars: %s",
+                                    self._device.device_config.address,
+                                    file_id[:120] + "...",
+                                )
+                                skipped += 1
+                                continue
+                            try:
+                                sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
+                                # Re-attach thumbnail from JSON-RPC response if present
+                                thumb = file.get("thumbnail") or (file.get("art") or {}).get("thumb")
+                                if thumb:
+                                    sub.thumbnail = self.get_artwork_url(thumb)
+                                item.items.append(sub)
+                            # pylint: disable=W0718
+                            except Exception as item_ex:
+                                _LOG.warning(
+                                    "[%s] Skipping malformed addon entry %s: %s",
+                                    self._device.device_config.address,
+                                    file_id[:120],
+                                    item_ex,
+                                )
+                                skipped += 1
+                        total = data.get("limits", {}).get("total", len(item.items) + skipped)
+                        paging.count = max(total - skipped, len(item.items))
                         # If this directory is a saved favorite that was previously
                         # broken, clear the flag now that it works again.
                         cfg = self._device.device_config
@@ -1142,11 +1167,32 @@ class MediaBrowser:
                     )
                     data = await self._device.server.Files.GetDirectory(**arguments)
                     if data:
+                        skipped = 0
                         for file in data["files"]:
+                            file_id = file.get("file", "") or ""
+                            if len(file_id) > 255:
+                                _LOG.warning(
+                                    "[%s] Skipping source entry with media_id > 255 chars: %s",
+                                    self._device.device_config.address,
+                                    file_id[:120] + "...",
+                                )
+                                skipped += 1
+                                continue
                             # Thumbnail extraction only works with pictures
                             extract_thumbnail = media == KodiMediaTypes.PICTURES.value
-                            item.items.append(self.get_item_from_file(file, media_type, extract_thumbnail))
-                        paging.count = data.get("limits", {}).get("total", 0)
+                            try:
+                                item.items.append(self.get_item_from_file(file, media_type, extract_thumbnail))
+                            # pylint: disable=W0718
+                            except Exception as item_ex:
+                                _LOG.warning(
+                                    "[%s] Skipping malformed source entry %s: %s",
+                                    self._device.device_config.address,
+                                    file_id[:120],
+                                    item_ex,
+                                )
+                                skipped += 1
+                        total = data.get("limits", {}).get("total", 0)
+                        paging.count = max(total - skipped, len(item.items))
                         if self._back_support:
                             paging.count = paging.count + back_buttons
                     return item, paging

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -22,6 +22,8 @@ from ucapi.media_player import (
     SearchMediaFilter,
 )
 
+import config
+import favorites
 from const import (
     IKodiDevice,
     KodiMediaTypes,
@@ -190,8 +192,201 @@ class MediaBrowser:
             elif mid == "kodi://addons/audio":
                 if not await self._is_addons_available("audio"):
                     continue
+            elif mid == "kodi://favorites":
+                if not favorites.list_favorites(self._device.device_config.favorites):
+                    continue
             result.append(it)
         return result
+
+    # ---------------------------------------------------------------- favorites
+    def _persist_favorites(self) -> None:
+        """Persist the current device configuration after a favorites change."""
+        try:
+            if config.devices is not None:
+                config.devices.update(self._device.device_config)
+        # pylint: disable=W0718
+        except Exception as ex:
+            _LOG.warning(
+                "[%s] Could not persist favorites: %s",
+                self._device.device_config.address,
+                ex,
+            )
+
+    def _favorite_item(self, fav: dict, *, with_unpin: bool = False) -> BrowseMediaItem:
+        """Render a saved favorite as a BrowseMediaItem.
+
+        When ``with_unpin`` is True, the returned item itself toggles (unpins)
+        the favorite on click; this is used in the management view so dead
+        favorites can still be removed without navigating into them.
+        """
+        title = fav.get("title") or fav.get("media_id", "")
+        if fav.get("broken"):
+            title = f"⚠ {title}"
+        if with_unpin:
+            return BrowseMediaItem(
+                title=self.get_localized("Unpin") + ": " + title,
+                media_id=favorites.encode_toggle(
+                    fav["media_id"], fav["media_type"], fav.get("title", title), favorites.FAVORITES_MANAGE
+                ),
+                media_class=MediaClass.DIRECTORY,
+                media_type=MediaContentType.URL.value,
+                can_browse=True,
+                can_play=False,
+                thumbnail=fav.get("thumbnail"),
+                items=[],
+            )
+        # Normal favorite: keep the original media_id/media_type so the
+        # standard browse/play handlers do the work. We still wrap browsing
+        # in a try/except later so that broken plugin:// targets do not
+        # leave the user stuck.
+        media_id = fav["media_id"]
+        media_type = fav["media_type"]
+        can_play = media_type in ("channel",) or media_id.startswith("plugin://") and "?" in media_id
+        return BrowseMediaItem(
+            title=title,
+            media_id=media_id,
+            media_class=MediaClass.DIRECTORY,
+            media_type=media_type,
+            can_browse=True,
+            can_play=can_play,
+            thumbnail=fav.get("thumbnail"),
+            items=[],
+        )
+
+    def _build_favorites_root(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Render the ``kodi://favorites`` root listing."""
+        item = self.get_root_item()
+        item.media_id = favorites.FAVORITES_ROOT
+        item.title = self.get_localized("Favorites")
+        favs = favorites.list_favorites(self._device.device_config.favorites)
+        sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
+        for fav in favs:
+            sub.append(self._favorite_item(fav))
+        if favs:
+            sub.append(
+                BrowseMediaItem(
+                    title=self.get_localized("Manage favorites"),
+                    media_id=favorites.FAVORITES_MANAGE,
+                    media_class=MediaClass.DIRECTORY,
+                    media_type=MediaContentType.URL.value,
+                    can_browse=True,
+                    can_play=False,
+                    items=[],
+                )
+            )
+        item.items = sub
+        paging.count = len(sub)
+        return item, paging
+
+    def _build_favorites_manage(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Render the management view (one toggle entry per favorite + cleanup)."""
+        item = self.get_root_item()
+        item.media_id = favorites.FAVORITES_MANAGE
+        item.title = self.get_localized("Manage favorites")
+        favs = favorites.list_favorites(self._device.device_config.favorites)
+        sub: list[BrowseMediaItem] = [self.get_back_item(favorites.FAVORITES_ROOT)]
+        for fav in favs:
+            sub.append(self._favorite_item(fav, with_unpin=True))
+        if any(f.get("broken") for f in favs):
+            sub.append(
+                BrowseMediaItem(
+                    title=self.get_localized("Cleanup broken favorites"),
+                    media_id=favorites.FAVORITES_CLEANUP,
+                    media_class=MediaClass.DIRECTORY,
+                    media_type=MediaContentType.URL.value,
+                    can_browse=True,
+                    can_play=False,
+                    items=[],
+                )
+            )
+        item.items = sub
+        paging.count = len(sub)
+        return item, paging
+
+    def _build_confirmation(
+        self, message: str, parent_id: str, paging: PaginationOptions
+    ) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Build a tiny browse view used as feedback after a favorites action."""
+        item = self.get_root_item()
+        item.media_id = parent_id
+        item.title = message
+        item.items = [self.get_back_item(parent_id)]
+        paging.count = 1
+        return item, paging
+
+    def _handle_favorites_toggle(
+        self, media_id: str, paging: PaginationOptions
+    ) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Add or remove a favorite based on a toggle media_id."""
+        params = favorites.decode_toggle(media_id)
+        if not params:
+            return self._build_confirmation(
+                self.get_localized("Invalid favorite"), favorites.FAVORITES_ROOT, paging
+            )
+        cfg = self._device.device_config
+        if cfg.favorites is None:
+            cfg.favorites = []
+        parent = params.get("parent") or favorites.FAVORITES_ROOT
+        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
+            favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
+            self._persist_favorites()
+            return self._build_confirmation(self.get_localized("Unpinned"), parent, paging)
+        favorites.add(
+            cfg.favorites,
+            params["media_id"],
+            params["media_type"],
+            params.get("title") or params["media_id"],
+        )
+        self._persist_favorites()
+        return self._build_confirmation(self.get_localized("Pinned"), parent, paging)
+
+    def _handle_favorites_cleanup(
+        self, paging: PaginationOptions
+    ) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Remove all broken favorites."""
+        cfg = self._device.device_config
+        removed = favorites.remove_broken(cfg.favorites or [])
+        if removed:
+            self._persist_favorites()
+        return self._build_confirmation(
+            self.get_localized("Removed {0} broken favorites").replace("{0}", str(removed)),
+            favorites.FAVORITES_ROOT,
+            paging,
+        )
+
+    def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem:
+        """Build the pin/unpin entry shown at the top of pinnable directories."""
+        pinned = favorites.is_favorite(
+            self._device.device_config.favorites, media_id, media_type
+        )
+        label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
+        return BrowseMediaItem(
+            title=self.get_localized(label_key),
+            media_id=favorites.encode_toggle(media_id, media_type, title, parent=media_id),
+            media_class=MediaClass.DIRECTORY,
+            media_type=MediaContentType.URL.value,
+            can_browse=True,
+            can_play=False,
+            items=[],
+        )
+
+    def _maybe_inject_pin_item(
+        self, item: BrowseMediaItem, media_id: str | None, media_type: str | None
+    ) -> None:
+        """Insert the pin/unpin item at the top of ``item.items`` if applicable."""
+        if not media_id or not item or not item.items:
+            return
+        if not favorites.can_pin(media_id, media_type):
+            return
+        title = item.title or media_id
+        # Skip if already injected (defensive against double calls)
+        if item.items and isinstance(item.items[0], BrowseMediaItem) and (
+            item.items[0].media_id or ""
+        ).startswith(favorites.FAVORITES_TOGGLE_PREFIX):
+            return
+        # Insert just AFTER an existing back item if present, otherwise at top
+        insert_at = 1 if item.items and item.items[0].title in ("..", self.get_localized("..")) else 0
+        item.items.insert(insert_at, self._make_pin_item(media_id, media_type or "", title))
 
     def get_localized(self, value: str) -> str:
         """Return localized value."""
@@ -653,10 +848,26 @@ class MediaBrowser:
                 await self.add_now_playing_item(items, 0)
                 for sub_item in items:
                     sub_item.title = self.get_localized(sub_item.title)
+                # Optionally inject favorites flat into the browse root
+                if getattr(self._device.device_config, "favorites_in_root", False):
+                    favs = favorites.list_favorites(self._device.device_config.favorites)
+                    for fav in favs:
+                        items.insert(0, self._favorite_item(fav))
                 paging.count = len(items)
                 item.title = self.get_localized(item.title)
                 item.items = items
                 return item, paging
+
+            # ---------- Favorites special routes ----------
+            if media_id == favorites.FAVORITES_ROOT:
+                return self._build_favorites_root(paging)
+            if media_id == favorites.FAVORITES_MANAGE:
+                return self._build_favorites_manage(paging)
+            if media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX):
+                return self._handle_favorites_toggle(media_id, paging)
+            if media_id == favorites.FAVORITES_CLEANUP:
+                return self._handle_favorites_cleanup(paging)
+            # ----------------------------------------------
 
             # Find given media_id in the library items
             entry: KodiMediaEntry | None = None
@@ -862,6 +1073,15 @@ class MediaBrowser:
                             ex,
                         )
                         data = None
+                        # If this id is a saved favorite, flag it as broken and
+                        # always offer an unpin button so the user is not stuck.
+                        cfg = self._device.device_config
+                        if favorites.is_favorite(cfg.favorites, media_id, media_type or "addondir"):
+                            if favorites.mark_broken(cfg.favorites, media_id, media_type or "addondir", True):
+                                self._persist_favorites()
+                            item.items.append(
+                                self._make_pin_item(media_id, media_type or "addondir", media_id)
+                            )
                     if data:
                         for file in data.get("files", []) or []:
                             sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
@@ -871,6 +1091,14 @@ class MediaBrowser:
                                 sub.thumbnail = self.get_artwork_url(thumb)
                             item.items.append(sub)
                         paging.count = data.get("limits", {}).get("total", len(item.items))
+                        # If this directory is a saved favorite that was previously
+                        # broken, clear the flag now that it works again.
+                        cfg = self._device.device_config
+                        if favorites.mark_broken(cfg.favorites, media_id, media_type or "addondir", False):
+                            self._persist_favorites()
+                    # Inject the pin/unpin shortcut at the top so the user can
+                    # bookmark this exact location.
+                    self._maybe_inject_pin_item(item, media_id, media_type or "addondir")
                     return item, paging
                 if media_type.startswith("kodi://sources"):
                     back_buttons = 0
@@ -1264,6 +1492,8 @@ class MediaBrowser:
                         paging.count = paging.count + 1
                     for channel in channels.get("channels", []):
                         item.items.append(self.get_item_from_channel(channel))
+                    # Allow pinning of the whole channel group
+                    self._maybe_inject_pin_item(item, media_id, "channelgroup")
                 elif media_type == MediaContentType.PLAYLIST.value:
                     item = self.get_root_item(MediaClass.PLAYLIST, MediaContentType.PLAYLIST)
                     limit = paging.limit
@@ -2261,5 +2491,15 @@ KODI_BROWSING: list[KodiMediaEntry] = [
         },
         child_media_type=MediaContentType.URL,
         output=KodiObjectType.ADDON,
+    ),
+    # ---- Favorites (pinned shortcuts) ----
+    KodiMediaEntry(
+        parent_id=None,
+        title="Favorites",
+        media_type=MediaContentType.URL,
+        media_class=MediaClass.DIRECTORY,
+        media_id="kodi://favorites",
+        child_media_type=MediaContentType.URL,
+        output=KodiObjectType.EMPTY,
     ),
 ]

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -1074,8 +1074,7 @@ class MediaBrowser:
                 paging = PaginationOptions(page=paging.page, limit=paging.limit, count=0)
 
             if media_id and (
-                media_id.startswith(favorites.FAVORITES_ROOT)
-                or media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX)
+                media_id.startswith(favorites.FAVORITES_ROOT) or media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX)
             ):
                 _LOG.debug(
                     "[%s] Browse request: media_id=%s media_type=%s page=%s limit=%s",

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -218,22 +218,33 @@ class MediaBrowser:
                 ex,
             )
 
-    def _favorite_item(self, fav: dict, *, with_unpin: bool = False) -> BrowseMediaItem:
+    def _favorite_item(self, fav: dict, *, with_unpin: bool = False) -> BrowseMediaItem | None:
         """Render a saved favorite as a BrowseMediaItem.
 
         When ``with_unpin`` is True, the returned item itself toggles (unpins)
         the favorite on click; this is used in the management view so dead
         favorites can still be removed without navigating into them.
+
+        Returns None when the resulting media_id would exceed the ucapi
+        255-char cap (would otherwise crash the whole browse listing).
         """
         title = fav.get("title") or fav.get("media_id", "")
         if fav.get("broken"):
             title = f"⚠ {title}"
         if with_unpin:
+            toggle_id = favorites.encode_toggle(
+                fav["media_id"], fav["media_type"], fav.get("title", title), favorites.FAVORITES_MANAGE
+            )
+            if len(toggle_id) > MAX_MEDIA_ID_LEN:
+                _LOG.warning(
+                    "Skipping unpin item, toggle media_id exceeds %d chars for %s",
+                    MAX_MEDIA_ID_LEN,
+                    str(fav.get("media_id", ""))[:120],
+                )
+                return None
             return BrowseMediaItem(
                 title=self.get_localized("Unpin") + ": " + title,
-                media_id=favorites.encode_toggle(
-                    fav["media_id"], fav["media_type"], fav.get("title", title), favorites.FAVORITES_MANAGE
-                ),
+                media_id=toggle_id,
                 media_class=MediaClass.DIRECTORY,
                 media_type=MediaContentType.URL.value,
                 can_browse=True,
@@ -247,6 +258,13 @@ class MediaBrowser:
         # leave the user stuck.
         media_id = fav["media_id"]
         media_type = fav["media_type"]
+        if len(media_id) > MAX_MEDIA_ID_LEN:
+            _LOG.warning(
+                "Skipping favorite, media_id exceeds %d chars: %s",
+                MAX_MEDIA_ID_LEN,
+                media_id[:120],
+            )
+            return None
         can_play = media_type in ("channel",) or media_id.startswith("plugin://") and "?" in media_id
         return BrowseMediaItem(
             title=title,
@@ -267,7 +285,9 @@ class MediaBrowser:
         favs = favorites.list_favorites(self._device.device_config.favorites)
         sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
         for fav in favs:
-            sub.append(self._favorite_item(fav))
+            entry = self._favorite_item(fav)
+            if entry is not None:
+                sub.append(entry)
         if favs:
             sub.append(
                 BrowseMediaItem(
@@ -292,7 +312,9 @@ class MediaBrowser:
         favs = favorites.list_favorites(self._device.device_config.favorites)
         sub: list[BrowseMediaItem] = [self.get_back_item(favorites.FAVORITES_ROOT)]
         for fav in favs:
-            sub.append(self._favorite_item(fav, with_unpin=True))
+            entry = self._favorite_item(fav, with_unpin=True)
+            if entry is not None:
+                sub.append(entry)
         if any(f.get("broken") for f in favs):
             sub.append(
                 BrowseMediaItem(
@@ -356,13 +378,22 @@ class MediaBrowser:
             paging,
         )
 
-    def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem:
-        """Build the pin/unpin entry shown at the top of pinnable directories."""
+    def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem | None:
+        """Build the pin/unpin entry. Returns None when the toggle URL would exceed 255 chars."""
         pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
         label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
+        toggle_id = favorites.encode_toggle(media_id, media_type, title, parent=media_id)
+        if len(toggle_id) > MAX_MEDIA_ID_LEN:
+            _LOG.debug(
+                "Skipping pin item, toggle media_id would exceed %d chars (%d) for %s",
+                MAX_MEDIA_ID_LEN,
+                len(toggle_id),
+                media_id[:120],
+            )
+            return None
         return BrowseMediaItem(
             title=self.get_localized(label_key),
-            media_id=favorites.encode_toggle(media_id, media_type, title, parent=media_id),
+            media_id=toggle_id,
             media_class=MediaClass.DIRECTORY,
             media_type=MediaContentType.URL.value,
             can_browse=True,
@@ -386,7 +417,9 @@ class MediaBrowser:
             return
         # Insert just AFTER an existing back item if present, otherwise at top
         insert_at = 1 if item.items and item.items[0].title in ("..", self.get_localized("..")) else 0
-        item.items.insert(insert_at, self._make_pin_item(media_id, media_type or "", title))
+        pin = self._make_pin_item(media_id, media_type or "", title)
+        if pin is not None:
+            item.items.insert(insert_at, pin)
 
     def get_localized(self, value: str) -> str:
         """Return localized value."""
@@ -804,25 +837,28 @@ class MediaBrowser:
         """Add now playing item."""
         current_playlist = await self._device.get_current_playlist()
         if current_playlist and current_playlist.position >= 0:
-            art = get_artwork(current_playlist.playlist["items"][current_playlist.position].get("art", None))
+            playing = current_playlist.playlist["items"][current_playlist.position]
+            art = get_artwork(playing.get("art", None))
             if art:
                 art = self.get_artwork_url(art)
-            duration = current_playlist.playlist["items"][current_playlist.position].get("duration", None)
+            duration = playing.get("duration", None)
+            # ucapi rejects empty strings for album/artist ("must be at least 1
+            # characters"); coerce "" to None to avoid aborting the whole root
+            # listing when Kodi returns an empty tag.
+            album = playing.get("album", None) or None
+            artist = get_element(playing.get("artist", None)) or None
             items.insert(
                 position,
                 BrowseMediaItem(
-                    title=f"{self.get_localized('Now playing')} "
-                    f"({current_playlist.playlist['items'][current_playlist.position].get('label', '')})",
+                    title=f"{self.get_localized('Now playing')} " f"({playing.get('label', '')})",
                     media_class=MediaClass.PLAYLIST,
                     media_type=MediaClass.PLAYLIST,
                     media_id="kodi://playing",
                     thumbnail=art,
                     can_browse=True,
                     duration=int(duration) if duration else None,
-                    album=current_playlist.playlist["items"][current_playlist.position].get("album", None),
-                    artist=get_element(
-                        current_playlist.playlist["items"][current_playlist.position].get("artist", None)
-                    ),
+                    album=album,
+                    artist=artist,
                 ),
             )
 
@@ -869,7 +905,9 @@ class MediaBrowser:
                 if getattr(self._device.device_config, "favorites_in_root", False):
                     favs = favorites.list_favorites(self._device.device_config.favorites)
                     for fav in favs:
-                        items.insert(0, self._favorite_item(fav))
+                        entry = self._favorite_item(fav)
+                        if entry is not None:
+                            items.insert(0, entry)
                 paging.count = len(items)
                 item.title = self.get_localized(item.title)
                 item.items = items

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -215,7 +215,7 @@ class MediaBrowser:
                 if not await self._is_addons_available("audio"):
                     continue
             elif mid == "kodi://favorites":
-                if not await favorites.get_kodi_favourites(self._device.server):
+                if not await favorites.get_kodi_favourites(self._device.client):
                     continue
             result.append(it)
         return result
@@ -244,7 +244,7 @@ class MediaBrowser:
         item = self.get_root_item()
         item.media_id = favorites.FAVORITES_ROOT
         item.title = self.get_localized("Favorites")
-        favs = await favorites.get_kodi_favourites(self._device.server)
+        favs = await favorites.get_kodi_favourites(self._device.client)
         sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
         for fav in favs:
             title = fav.get("title", "")
@@ -792,7 +792,7 @@ class MediaBrowser:
                     sub_item.title = self.get_localized(sub_item.title)
                 # Optionally inject Kodi favourites flat into the browse root
                 if getattr(self._device.device_config, "favorites_in_root", False):
-                    favs = await favorites.get_kodi_favourites(self._device.server)
+                    favs = await favorites.get_kodi_favourites(self._device.client)
                     root_favorites: list[BrowseMediaItem] = []
                     has_more_favorites = len(favs) > MAX_ROOT_FAVORITES
                     visible_favorites = (

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -36,6 +36,13 @@ _LOG = logging.getLogger(__name__)
 
 # pylint: disable=C0302,R0801,R0917,W1405
 
+# ucapi BrowseMediaItem.media_id is hard-capped at 255 characters.
+# Some Kodi addons (e.g. plugin.video.twitch followed channels) emit child
+# entries whose 'file' URL exceeds that limit. We must filter them out at
+# the construction sites or the BrowseMediaItem constructor raises
+# ValueError mid-loop and aborts the whole listing.
+MAX_MEDIA_ID_LEN = 255
+
 
 MEDIA_CONTENT_LABELS = {
     MediaContentType.MOVIE: "Videos",
@@ -427,13 +434,23 @@ class MediaBrowser:
             items=[],
         )
 
-    def get_item_from_file(self, file: dict[str, Any], media_type: str, extract_thumbnail=True) -> BrowseMediaItem:
-        """Build item from file."""
+    def get_item_from_file(
+        self, file: dict[str, Any], media_type: str, extract_thumbnail=True
+    ) -> BrowseMediaItem | None:
+        """Build item from file. Returns None when media_id exceeds the ucapi 255-char cap."""
+        media_id = file.get("file", "") or ""
+        if len(media_id) > MAX_MEDIA_ID_LEN:
+            _LOG.warning(
+                "Skipping file entry, media_id exceeds %d chars: %s...",
+                MAX_MEDIA_ID_LEN,
+                media_id[:120],
+            )
+            return None
         label = strip_kodi_formatting(file.get("label", ""))
         if file.get("filetype", "directory") == "directory":
             return BrowseMediaItem(
                 title=label,
-                media_id=file.get("file", ""),
+                media_id=media_id,
                 media_class=MediaClass.DIRECTORY,
                 media_type=media_type,
                 can_browse=True,
@@ -449,7 +466,7 @@ class MediaBrowser:
             thumbnail: str | None = None
         return BrowseMediaItem(
             title=label,
-            media_id=file.get("file", ""),
+            media_id=media_id,
             media_class=MediaClass.VIDEO,
             media_type=media_type,
             can_browse=False,
@@ -514,12 +531,19 @@ class MediaBrowser:
             duration=MediaBrowser.get_duration(movie),
         )
 
-    def get_item_from_episode(self, episode: dict[str, Any]) -> BrowseMediaItem:
-        """Build item from episode."""
+    def get_item_from_episode(self, episode: dict[str, Any]) -> BrowseMediaItem | None:
+        """Build item from episode. Returns None when media_id exceeds the ucapi 255-char cap."""
         art = get_artwork(episode.get("art", None))
         if art:
             art = self.get_artwork_url(art)
         media_id = str(episode.get("file", ""))
+        if len(media_id) > MAX_MEDIA_ID_LEN:
+            _LOG.warning(
+                "Skipping episode entry, media_id exceeds %d chars: %s...",
+                MAX_MEDIA_ID_LEN,
+                media_id[:120],
+            )
+            return None
         subtitles: list[str] = []
         # Not necessary, season and episode already in label
         # episode_season = None
@@ -946,7 +970,9 @@ class MediaBrowser:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://sources"))
                     for file in data.get("files", data.get("sources", [])):
-                        item.items.append(self.get_item_from_file(file, media_type, False))
+                        sub = self.get_item_from_file(file, media_type, False)
+                        if sub is not None:
+                            item.items.append(sub)
                 elif entry.output == KodiObjectType.MOVIE:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://videos", str(MediaContentType.MOVIE.value)))
@@ -960,7 +986,9 @@ class MediaBrowser:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://tvshows", str(MediaContentType.TV_SHOW.value)))
                     for episode in data.get("episodes", []):
-                        item.items.append(self.get_item_from_episode(episode))
+                        sub = self.get_item_from_episode(episode)
+                        if sub is not None:
+                            item.items.append(sub)
                 elif entry.output == KodiObjectType.TV_SHOW:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://tvshows", str(MediaContentType.TV_SHOW.value)))
@@ -970,7 +998,9 @@ class MediaBrowser:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://tvshows", str(MediaContentType.TV_SHOW.value)))
                     for episode in data.get("episodes", []):
-                        item.items.append(self.get_item_from_episode(episode))
+                        sub = self.get_item_from_episode(episode)
+                        if sub is not None:
+                            item.items.append(sub)
                 elif entry.output == KodiObjectType.ALBUM:
                     if self.add_back_entry(item.media_id, paging):
                         item.items.append(self.get_back_item("kodi://music", str(MediaContentType.MUSIC.value)))
@@ -1074,39 +1104,16 @@ class MediaBrowser:
                                 self._persist_favorites()
                             item.items.append(self._make_pin_item(media_id, media_type or "addondir", media_id))
                     if data:
-                        skipped = 0
                         for file in data.get("files", []) or []:
-                            file_id = file.get("file", "") or ""
-                            # ucapi caps media_id at 255 chars; some Kodi addons
-                            # (e.g. Twitch followed channels) emit longer URLs.
-                            # Skip those entries instead of aborting the whole
-                            # listing so the user still sees the rest.
-                            if len(file_id) > 255:
-                                _LOG.warning(
-                                    "[%s] Skipping addon entry with media_id > 255 chars: %s",
-                                    self._device.device_config.address,
-                                    file_id[:120] + "...",
-                                )
-                                skipped += 1
+                            sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
+                            if sub is None:
                                 continue
-                            try:
-                                sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
-                                # Re-attach thumbnail from JSON-RPC response if present
-                                thumb = file.get("thumbnail") or (file.get("art") or {}).get("thumb")
-                                if thumb:
-                                    sub.thumbnail = self.get_artwork_url(thumb)
-                                item.items.append(sub)
-                            # pylint: disable=W0718
-                            except Exception as item_ex:
-                                _LOG.warning(
-                                    "[%s] Skipping malformed addon entry %s: %s",
-                                    self._device.device_config.address,
-                                    file_id[:120],
-                                    item_ex,
-                                )
-                                skipped += 1
-                        total = data.get("limits", {}).get("total", len(item.items) + skipped)
-                        paging.count = max(total - skipped, len(item.items))
+                            # Re-attach thumbnail from JSON-RPC response if present
+                            thumb = file.get("thumbnail") or (file.get("art") or {}).get("thumb")
+                            if thumb:
+                                sub.thumbnail = self.get_artwork_url(thumb)
+                            item.items.append(sub)
+                        paging.count = data.get("limits", {}).get("total", len(item.items))
                         # If this directory is a saved favorite that was previously
                         # broken, clear the flag now that it works again.
                         cfg = self._device.device_config
@@ -1167,32 +1174,13 @@ class MediaBrowser:
                     )
                     data = await self._device.server.Files.GetDirectory(**arguments)
                     if data:
-                        skipped = 0
                         for file in data["files"]:
-                            file_id = file.get("file", "") or ""
-                            if len(file_id) > 255:
-                                _LOG.warning(
-                                    "[%s] Skipping source entry with media_id > 255 chars: %s",
-                                    self._device.device_config.address,
-                                    file_id[:120] + "...",
-                                )
-                                skipped += 1
-                                continue
                             # Thumbnail extraction only works with pictures
                             extract_thumbnail = media == KodiMediaTypes.PICTURES.value
-                            try:
-                                item.items.append(self.get_item_from_file(file, media_type, extract_thumbnail))
-                            # pylint: disable=W0718
-                            except Exception as item_ex:
-                                _LOG.warning(
-                                    "[%s] Skipping malformed source entry %s: %s",
-                                    self._device.device_config.address,
-                                    file_id[:120],
-                                    item_ex,
-                                )
-                                skipped += 1
-                        total = data.get("limits", {}).get("total", 0)
-                        paging.count = max(total - skipped, len(item.items))
+                            sub = self.get_item_from_file(file, media_type, extract_thumbnail)
+                            if sub is not None:
+                                item.items.append(sub)
+                        paging.count = data.get("limits", {}).get("total", 0)
                         if self._back_support:
                             paging.count = paging.count + back_buttons
                     return item, paging
@@ -1283,7 +1271,9 @@ class MediaBrowser:
                         show_title = episodes["episodes"][0].get("showtitle", "")
                         item.title = f"{show_title} - S{season}"
                     for episode in episodes["episodes"]:
-                        item.items.append(self.get_item_from_episode(episode))
+                        sub = self.get_item_from_episode(episode)
+                        if sub is not None:
+                            item.items.append(sub)
 
                 elif media_type == MediaContentType.ALBUM.value:
                     item = self.get_root_item(MediaClass.ALBUM, MediaContentType.MUSIC)

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -167,11 +167,14 @@ class MediaBrowser:
                     return True
             self._pvr_available = False
         # pylint: disable=W0718
-        except Exception:
-            # Fail-open on transient connection errors so root entries remain
-            # visible and recover automatically once Kodi is reachable again.
-            self._pvr_available = None
-            return True
+        except Exception as ex:
+            # Do not cache transient probe failures as "unavailable".
+            _LOG.debug(
+                "[%s] PVR availability probe failed, will retry: %s",
+                self._device.device_config.address,
+                ex,
+            )
+            return False
         return self._pvr_available
 
     async def _is_addons_available(self, content: str) -> bool:
@@ -186,10 +189,15 @@ class MediaBrowser:
             )
             available = bool((result or {}).get("addons"))
         # pylint: disable=W0718
-        except Exception:
-            # Fail-open on transient connection errors so root entries remain
-            # visible and recover automatically once Kodi is reachable again.
-            return True
+        except Exception as ex:
+            # Do not cache transient probe failures as "unavailable".
+            _LOG.debug(
+                "[%s] Addons(%s) availability probe failed, will retry: %s",
+                self._device.device_config.address,
+                content,
+                ex,
+            )
+            return False
         setattr(self, cache_attr, available)
         return available
 

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -545,10 +545,10 @@ class MediaBrowser:
         """Build the pin/unpin entry."""
         pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
         label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
-        # UX workaround: after pin/unpin from deep folder views, jump back to
-        # Home so users immediately see updated root favorites and don't need
-        # to back out through the whole navigation path.
-        parent = "kodi://"
+        # After pin/unpin, stay in the current directory by re-browsing it.
+        # This avoids stale back-navigation levels on the remote since the
+        # toggle response replaces the current screen with the same view.
+        parent = media_id
         toggle_id = self._build_toggle_media_id(media_id, media_type, title, parent=parent)
         return BrowseMediaItem(
             title=self.get_localized(label_key),

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -248,16 +248,19 @@ class MediaBrowser:
         sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
         for fav in favs:
             title = fav.get("title", "")
-            path = fav.get("path") or fav.get("window") or fav.get("windowparameter") or ""
+            path = fav.get("path") or fav.get("windowparameter") or fav.get("window") or ""
             if not path:
                 continue
+            media_type = MediaContentType.URL.value
+            if fav.get("window") == "videos":
+                media_type = "kodi://sources/videos"
             thumbnail = fav.get("thumbnail") or None
             sub.append(
                 BrowseMediaItem(
                     title=title,
                     media_id=path,
                     media_class=MediaClass.DIRECTORY,
-                    media_type=MediaContentType.URL.value,
+                    media_type=media_type,
                     can_browse=True,
                     can_play=True,
                     thumbnail=thumbnail,

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -22,7 +22,6 @@ from ucapi.media_player import (
     SearchMediaFilter,
 )
 
-import config
 import favorites
 from const import (
     IKodiDevice,
@@ -148,11 +147,8 @@ class MediaBrowser:
         self._pvr_available: bool | None = None
         self._addons_video_available: bool | None = None
         self._addons_audio_available: bool | None = None
-        # Runtime cache for compact favorites toggle actions. Needed when the
-        # original media_id is too long to fit in ucapi's 255-char media_id cap.
-        self._favorites_toggle_cache: dict[str, dict[str, str]] = {}
         # Remember browse entry titles by media_id so deep plugin:// navigation
-        # and favorites can show a human-readable label instead of raw URLs.
+        # can show a human-readable label instead of raw URLs.
         self._browse_title_cache: dict[str, str] = {}
 
     async def _is_pvr_available(self) -> bool:
@@ -219,44 +215,10 @@ class MediaBrowser:
                 if not await self._is_addons_available("audio"):
                     continue
             elif mid == "kodi://favorites":
-                if not favorites.list_favorites(self._device.device_config.favorites):
+                if not await favorites.get_kodi_favourites(self._device.server):
                     continue
             result.append(it)
         return result
-
-    # ---------------------------------------------------------------- favorites
-    def _persist_favorites(self) -> None:
-        """Persist the current device configuration after a favorites change."""
-        try:
-            if config.devices is not None:
-                config.devices.update(self._device.device_config)
-        # pylint: disable=W0718
-        except Exception as ex:
-            _LOG.warning(
-                "[%s] Could not persist favorites: %s",
-                self._device.device_config.address,
-                ex,
-            )
-
-    def _build_toggle_media_id(self, media_id: str, media_type: str, title: str, parent: str | None = None) -> str:
-        """Build a toggle media_id and transparently fall back to compact mode.
-
-        ucapi caps media_id to 255 chars. For long plugin paths, we keep the
-        real payload in an in-memory cache and expose only a short key.
-        """
-        toggle_id = favorites.encode_toggle(media_id, media_type, title, parent=parent)
-        if len(toggle_id) <= MAX_MEDIA_ID_LEN:
-            return toggle_id
-        key = favorites.make_toggle_key(media_id, media_type, title, parent=parent)
-        if len(self._favorites_toggle_cache) >= 2048:
-            self._favorites_toggle_cache.clear()
-        self._favorites_toggle_cache[key] = {
-            "media_id": media_id,
-            "media_type": media_type,
-            "title": title or media_id,
-            "parent": parent or "",
-        }
-        return favorites.encode_toggle_key(key)
 
     def _remember_browse_title(self, media_id: str | None, title: str | None) -> None:
         """Remember a browse title for later lookups."""
@@ -276,344 +238,35 @@ class MediaBrowser:
             return cached
         return default or media_id
 
-    def _get_source_label(self, media_id: str, media_type: str) -> str | None:
-        """Derive a human-readable source/addon label for a pinnable item.
-
-        For plugin:// addons: looks up the addon root title from the browse
-        cache (populated when the user browses the addons list).
-        For PVR / sources items: returns a fixed label.
-        Returns None when no label is available (no API call is made).
-        """
-        if media_id.startswith("plugin://"):
-            # plugin://plugin.video.twitch/following/... -> plugin.video.twitch
-            parts = media_id.split("/")
-            if len(parts) >= 3 and parts[2]:
-                addon_id = parts[2]
-                label = self._browse_title_cache.get(f"plugin://{addon_id}/")
-                if label:
-                    return label
-                # Fallback: titlecase the last segment of the addon_id
-                # e.g. "plugin.video.twitch" -> "Twitch"
-                segments = addon_id.split(".")
-                if segments:
-                    return segments[-1].capitalize()
-            return None
-        if media_id.startswith("kodi://pvr") or media_type in ("channel", "channelgroup"):
-            return self.get_localized("Live TV")
-        if media_id.startswith("kodi://sources"):
-            return self.get_localized("Sources")
-        return None
-
-    def _resolve_toggle_params(self, media_id: str) -> dict[str, str] | None:
-        """Resolve a favorites toggle media_id (direct payload or compact key)."""
-        params = favorites.decode_toggle(media_id)
-        if not params:
-            return None
-        key = params.get("key")
-        if not key:
-            return {
-                "media_id": str(params["media_id"]),
-                "media_type": str(params["media_type"]),
-                "title": str(params.get("title") or params["media_id"]),
-                "parent": str(params.get("parent") or ""),
-            }
-        cached = self._favorites_toggle_cache.get(str(key))
-        if not cached:
-            return None
-        return {
-            "media_id": str(cached.get("media_id") or ""),
-            "media_type": str(cached.get("media_type") or ""),
-            "title": str(cached.get("title") or cached.get("media_id") or ""),
-            "parent": str(cached.get("parent") or ""),
-        }
-
-    def _favorite_item(self, fav: dict, *, with_unpin: bool = False) -> BrowseMediaItem | None:
-        """Render a saved favorite as a BrowseMediaItem.
-
-        When ``with_unpin`` is True, the returned item itself toggles (unpins)
-        the favorite on click; this is used in the management view so dead
-        favorites can still be removed without navigating into them.
-
-        Returns None when the resulting media_id would exceed the ucapi
-        255-char cap (would otherwise crash the whole browse listing).
-        """
-        title = fav.get("title") or fav.get("media_id", "")
-        if fav.get("broken"):
-            title = f"⚠ {title}"
-        source: str | None = fav.get("source") or None
-        if with_unpin:
-            toggle_id = self._build_toggle_media_id(
-                fav["media_id"],
-                fav["media_type"],
-                fav.get("title", title),
-                favorites.FAVORITES_MANAGE,
-            )
-            return BrowseMediaItem(
-                title=self.get_localized("Unpin") + ": " + title,
-                subtitle=source,
-                media_id=toggle_id,
-                media_class=MediaClass.DIRECTORY,
-                media_type=MediaContentType.URL.value,
-                can_browse=True,
-                can_play=False,
-                thumbnail=fav.get("thumbnail"),
-                items=[],
-            )
-        # Normal favorite: keep the original media_id/media_type so the
-        # standard browse/play handlers do the work. We still wrap browsing
-        # in a try/except later so that broken plugin:// targets do not
-        # leave the user stuck.
-        media_id = fav["media_id"]
-        media_type = fav["media_type"]
-        if len(media_id) > MAX_MEDIA_ID_LEN:
-            _LOG.warning(
-                "Skipping favorite, media_id exceeds %d chars: %s",
-                MAX_MEDIA_ID_LEN,
-                media_id[:120],
-            )
-            return None
-        can_play = media_type in ("channel",) or media_id.startswith("plugin://") and "?" in media_id
-        return BrowseMediaItem(
-            title=title,
-            subtitle=source,
-            media_id=media_id,
-            media_class=MediaClass.DIRECTORY,
-            media_type=media_type,
-            can_browse=True,
-            can_play=can_play,
-            thumbnail=fav.get("thumbnail"),
-            items=[],
-        )
-
-    def _build_favorites_root(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
-        """Render the ``kodi://favorites`` root listing."""
+    # ---------------------------------------------------------------- favourites
+    async def _build_favorites_root(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
+        """Render the ``kodi://favorites`` listing from Kodi's native favourites."""
         item = self.get_root_item()
         item.media_id = favorites.FAVORITES_ROOT
         item.title = self.get_localized("Favorites")
-        favs = favorites.list_favorites(self._device.device_config.favorites)
+        favs = await favorites.get_kodi_favourites(self._device.server)
         sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
         for fav in favs:
-            entry = self._favorite_item(fav)
-            if entry is not None:
-                sub.append(entry)
-        if favs:
+            title = fav.get("title", "")
+            path = fav.get("path") or fav.get("window") or fav.get("windowparameter") or ""
+            if not path:
+                continue
+            thumbnail = fav.get("thumbnail") or None
             sub.append(
                 BrowseMediaItem(
-                    title=self.get_localized("Manage favorites"),
-                    media_id=favorites.FAVORITES_MANAGE,
+                    title=title,
+                    media_id=path,
                     media_class=MediaClass.DIRECTORY,
                     media_type=MediaContentType.URL.value,
                     can_browse=True,
-                    can_play=False,
+                    can_play=True,
+                    thumbnail=thumbnail,
                     items=[],
                 )
             )
         item.items = sub
         paging.count = len(sub)
         return item, paging
-
-    def _build_favorites_manage(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
-        """Render the management view (one toggle entry per favorite + cleanup)."""
-        item = self.get_root_item()
-        item.media_id = favorites.FAVORITES_MANAGE
-        item.title = self.get_localized("Manage favorites")
-        favs = favorites.list_favorites(self._device.device_config.favorites)
-        sub: list[BrowseMediaItem] = [self.get_back_item(favorites.FAVORITES_ROOT)]
-        for fav in favs:
-            entry = self._favorite_item(fav, with_unpin=True)
-            if entry is not None:
-                sub.append(entry)
-        if any(f.get("broken") for f in favs):
-            sub.append(
-                BrowseMediaItem(
-                    title=self.get_localized("Cleanup broken favorites"),
-                    media_id=favorites.FAVORITES_CLEANUP,
-                    media_class=MediaClass.DIRECTORY,
-                    media_type=MediaContentType.URL.value,
-                    can_browse=True,
-                    can_play=False,
-                    items=[],
-                )
-            )
-        item.items = sub
-        paging.count = len(sub)
-        return item, paging
-
-    def _build_confirmation(
-        self, message: str, parent_id: str, paging: PaginationOptions
-    ) -> tuple[BrowseMediaItem, PaginationOptions]:
-        """Build a tiny browse view used as feedback after a favorites action."""
-        item = self.get_root_item()
-        item.media_id = parent_id
-        item.title = message
-        item.items = [self.get_back_item(parent_id)]
-        paging.count = 1
-        return item, paging
-
-    async def _handle_favorites_toggle(
-        self, media_id: str, paging: PaginationOptions
-    ) -> tuple[BrowseMediaItem, PaginationOptions]:
-        """Add or remove a favorite based on a toggle media_id."""
-        params = self._resolve_toggle_params(media_id)
-        if not params:
-            return self._build_confirmation(self.get_localized("Invalid favorite"), favorites.FAVORITES_ROOT, paging)
-        cfg = self._device.device_config
-        if cfg.favorites is None:
-            cfg.favorites = []
-        parent = params.get("parent") or favorites.FAVORITES_ROOT
-        changed = False
-        action = "remove" if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]) else "add"
-        _LOG.debug(
-            "[%s] Favorites toggle request: action=%s target=%s type=%s parent=%s",
-            self._device.device_config.address,
-            action,
-            params["media_id"],
-            params["media_type"],
-            parent,
-        )
-        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
-            changed = favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
-        else:
-            source = self._get_source_label(params["media_id"], params["media_type"])
-            changed = favorites.add(
-                cfg.favorites,
-                params["media_id"],
-                params["media_type"],
-                params.get("title") or params["media_id"],
-                source=source,
-            )
-        if changed:
-            self._persist_favorites()
-
-        # Stay in context: return the same logical view the user was at so the
-        # toggle response replaces the current screen.  The hardware Back button
-        # on the remote may still show a stale cached level below – this is a
-        # remote firmware limitation that cannot be solved server-side.
-        if parent == favorites.FAVORITES_ROOT:
-            result = self._build_favorites_root(paging)
-            _LOG.debug(
-                "[%s] Favorites toggle response: view=%s title=%s items=%s",
-                self._device.device_config.address,
-                result[0].media_id,
-                result[0].title,
-                len(result[0].items or []),
-            )
-            return result
-        if parent == favorites.FAVORITES_MANAGE:
-            result = self._build_favorites_manage(paging)
-            _LOG.debug(
-                "[%s] Favorites toggle response: view=%s title=%s items=%s",
-                self._device.device_config.address,
-                result[0].media_id,
-                result[0].title,
-                len(result[0].items or []),
-            )
-            return result
-        refreshed = await self.browse_media(parent, params.get("media_type"), paging)
-        if refreshed is not None:
-            _LOG.debug(
-                "[%s] Favorites toggle response: view=%s title=%s items=%s",
-                self._device.device_config.address,
-                refreshed[0].media_id,
-                refreshed[0].title,
-                len(refreshed[0].items or []),
-            )
-            return refreshed
-        result = self._build_confirmation(self.get_localized("Pinned"), parent, paging)
-        _LOG.debug(
-            "[%s] Favorites toggle response: view=%s title=%s items=%s",
-            self._device.device_config.address,
-            result[0].media_id,
-            result[0].title,
-            len(result[0].items or []),
-        )
-        return result
-
-    async def _handle_favorites_play_toggle(self, media_id: str) -> None:
-        """Process a favorites toggle triggered via play_media.
-
-        Adds or removes a favorite silently.  No browse response is returned
-        because the remote stays on the current screen (play_media does not
-        push a navigation level).
-        """
-        params = self._resolve_toggle_params(media_id)
-        if not params:
-            return
-        cfg = self._device.device_config
-        if cfg.favorites is None:
-            cfg.favorites = []
-        _LOG.debug(
-            "[%s] Favorites play toggle: action=%s target=%s type=%s",
-            self._device.device_config.address,
-            "remove" if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]) else "add",
-            params["media_id"],
-            params["media_type"],
-        )
-        changed = False
-        if favorites.is_favorite(cfg.favorites, params["media_id"], params["media_type"]):
-            changed = favorites.remove(cfg.favorites, params["media_id"], params["media_type"])
-        else:
-            source = self._get_source_label(params["media_id"], params["media_type"])
-            changed = favorites.add(
-                cfg.favorites,
-                params["media_id"],
-                params["media_type"],
-                params.get("title") or params["media_id"],
-                source=source,
-            )
-        if changed:
-            self._persist_favorites()
-
-    def _handle_favorites_cleanup(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
-        """Remove all broken favorites."""
-        cfg = self._device.device_config
-        removed = favorites.remove_broken(cfg.favorites or [])
-        if removed:
-            self._persist_favorites()
-        return self._build_confirmation(
-            self.get_localized("Removed {0} broken favorites").replace("{0}", str(removed)),
-            favorites.FAVORITES_ROOT,
-            paging,
-        )
-
-    def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem | None:
-        """Build the pin/unpin entry."""
-        pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
-        label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
-        # Use can_play so the remote sends a play_media command instead of
-        # browse_media.  This avoids pushing a new navigation level and the
-        # stale back-entry that comes with it.  The play_media handler in
-        # MediaBrowser intercepts the toggle URL and silently updates the
-        # favorites list.
-        toggle_id = self._build_toggle_media_id(media_id, media_type, title, parent=media_id)
-        return BrowseMediaItem(
-            title=self.get_localized(label_key),
-            media_id=toggle_id,
-            media_class=MediaClass.DIRECTORY,
-            media_type=MediaContentType.URL.value,
-            can_browse=False,
-            can_play=True,
-        )
-
-    def _maybe_inject_pin_item(self, item: BrowseMediaItem, media_id: str | None, media_type: str | None) -> None:
-        """Insert the pin/unpin item at the top of ``item.items`` if applicable."""
-        if not media_id or not item or not item.items:
-            return
-        if not favorites.can_pin(media_id, media_type):
-            return
-        title = item.title or media_id
-        # Skip if already injected (defensive against double calls)
-        if (
-            item.items
-            and isinstance(item.items[0], BrowseMediaItem)
-            and (item.items[0].media_id or "").startswith(favorites.FAVORITES_TOGGLE_PREFIX)
-        ):
-            return
-        # Insert just AFTER an existing back item if present, otherwise at top
-        insert_at = 1 if item.items and item.items[0].title in ("..", self.get_localized("..")) else 0
-        pin = self._make_pin_item(media_id, media_type or "", title)
-        if pin is not None:
-            item.items.insert(insert_at, pin)
 
     def get_localized(self, value: str) -> str:
         """Return localized value."""
@@ -1108,9 +761,7 @@ class MediaBrowser:
             else:
                 paging = PaginationOptions(page=paging.page, limit=paging.limit, count=0)
 
-            if media_id and (
-                media_id.startswith(favorites.FAVORITES_ROOT) or media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX)
-            ):
+            if media_id and media_id.startswith(favorites.FAVORITES_ROOT):
                 _LOG.debug(
                     "[%s] Browse request: media_id=%s media_type=%s page=%s limit=%s",
                     self._device.device_config.address,
@@ -1139,22 +790,33 @@ class MediaBrowser:
                 await self.add_now_playing_item(items, 0)
                 for sub_item in items:
                     sub_item.title = self.get_localized(sub_item.title)
-                # Optionally inject favorites flat into the browse root
+                # Optionally inject Kodi favourites flat into the browse root
                 if getattr(self._device.device_config, "favorites_in_root", False):
-                    favs = favorites.list_favorites(self._device.device_config.favorites)
+                    favs = await favorites.get_kodi_favourites(self._device.server)
                     root_favorites: list[BrowseMediaItem] = []
                     has_more_favorites = len(favs) > MAX_ROOT_FAVORITES
                     visible_favorites = (
                         favs[: MAX_ROOT_FAVORITES - 1] if has_more_favorites else favs[:MAX_ROOT_FAVORITES]
                     )
                     for fav in visible_favorites:
-                        entry = self._favorite_item(fav)
-                        if entry is not None:
-                            root_favorites.append(entry)
+                        title = fav.get("title", "")
+                        path = fav.get("path") or fav.get("window") or fav.get("windowparameter") or ""
+                        if not path:
+                            continue
+                        root_favorites.append(
+                            BrowseMediaItem(
+                                title=title,
+                                media_id=path,
+                                media_class=MediaClass.DIRECTORY,
+                                media_type=MediaContentType.URL.value,
+                                can_browse=True,
+                                can_play=True,
+                                thumbnail=fav.get("thumbnail") or None,
+                                items=[],
+                            )
+                        )
 
                     if has_more_favorites:
-                        # Show first N-1 favorites directly and keep slot N as
-                        # a link to the full favorites view for the overflow.
                         root_favorites.append(
                             BrowseMediaItem(
                                 title=self.get_localized("Favorites"),
@@ -1166,8 +828,6 @@ class MediaBrowser:
                                 items=[],
                             )
                         )
-                        # Avoid duplicate favorites root entry when the
-                        # overflow link is already injected in the top section.
                         items = [x for x in items if x.media_id != favorites.FAVORITES_ROOT]
 
                     for entry in reversed(root_favorites):
@@ -1177,15 +837,9 @@ class MediaBrowser:
                 item.items = items
                 return item, paging
 
-            # ---------- Favorites special routes ----------
+            # ---------- Favourites special routes ----------
             if media_id == favorites.FAVORITES_ROOT:
-                return self._build_favorites_root(paging)
-            if media_id == favorites.FAVORITES_MANAGE:
-                return self._build_favorites_manage(paging)
-            if media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX):
-                return await self._handle_favorites_toggle(media_id, paging)
-            if media_id == favorites.FAVORITES_CLEANUP:
-                return self._handle_favorites_cleanup(paging)
+                return await self._build_favorites_root(paging)
             # ----------------------------------------------
 
             # Find given media_id in the library items
@@ -1399,13 +1053,6 @@ class MediaBrowser:
                             ex,
                         )
                         data = None
-                        # If this id is a saved favorite, flag it as broken and
-                        # always offer an unpin button so the user is not stuck.
-                        cfg = self._device.device_config
-                        if favorites.is_favorite(cfg.favorites, media_id, media_type or "addondir"):
-                            if favorites.mark_broken(cfg.favorites, media_id, media_type or "addondir", True):
-                                self._persist_favorites()
-                            item.items.append(self._make_pin_item(media_id, media_type or "addondir", media_id))
                     if data:
                         for file in data.get("files", []) or []:
                             sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)
@@ -1417,14 +1064,6 @@ class MediaBrowser:
                                 sub.thumbnail = self.get_artwork_url(thumb)
                             item.items.append(sub)
                         paging.count = data.get("limits", {}).get("total", len(item.items))
-                        # If this directory is a saved favorite that was previously
-                        # broken, clear the flag now that it works again.
-                        cfg = self._device.device_config
-                        if favorites.mark_broken(cfg.favorites, media_id, media_type or "addondir", False):
-                            self._persist_favorites()
-                    # Inject the pin/unpin shortcut at the top so the user can
-                    # bookmark this exact location.
-                    self._maybe_inject_pin_item(item, media_id, media_type or "addondir")
                     self._remember_browse_title(media_id, item.title)
                     return item, paging
                 if media_type.startswith("kodi://sources"):
@@ -1826,8 +1465,6 @@ class MediaBrowser:
                         item.items.append(self.get_item_from_channel(channel))
                     if resolved_title := await self._get_channel_group_title(parent_id, real_media_id):
                         item.title = resolved_title
-                    # Allow pinning of the whole channel group
-                    self._maybe_inject_pin_item(item, media_id, "channelgroup")
                 elif media_type == MediaContentType.PLAYLIST.value:
                     item = self.get_root_item(MediaClass.PLAYLIST, MediaContentType.PLAYLIST)
                     limit = paging.limit
@@ -1939,12 +1576,6 @@ class MediaBrowser:
         item: dict[str, Any] = {}
         if media_id is None or media_type is None:
             return StatusCodes.BAD_REQUEST
-        # Intercept favorites toggle URLs: the pin/unpin button uses
-        # can_play so the remote sends play_media instead of browse_media,
-        # avoiding a stale back-navigation level.
-        if media_id.startswith(favorites.FAVORITES_TOGGLE_PREFIX):
-            await self._handle_favorites_play_toggle(media_id)
-            return StatusCodes.OK
         if media_type == "channel":
             if media_id.startswith("kodi://"):
                 media_id = media_id.rstrip("/").rsplit("/", 1)[-1]

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -319,9 +319,7 @@ class MediaBrowser:
         """Add or remove a favorite based on a toggle media_id."""
         params = favorites.decode_toggle(media_id)
         if not params:
-            return self._build_confirmation(
-                self.get_localized("Invalid favorite"), favorites.FAVORITES_ROOT, paging
-            )
+            return self._build_confirmation(self.get_localized("Invalid favorite"), favorites.FAVORITES_ROOT, paging)
         cfg = self._device.device_config
         if cfg.favorites is None:
             cfg.favorites = []
@@ -339,9 +337,7 @@ class MediaBrowser:
         self._persist_favorites()
         return self._build_confirmation(self.get_localized("Pinned"), parent, paging)
 
-    def _handle_favorites_cleanup(
-        self, paging: PaginationOptions
-    ) -> tuple[BrowseMediaItem, PaginationOptions]:
+    def _handle_favorites_cleanup(self, paging: PaginationOptions) -> tuple[BrowseMediaItem, PaginationOptions]:
         """Remove all broken favorites."""
         cfg = self._device.device_config
         removed = favorites.remove_broken(cfg.favorites or [])
@@ -355,9 +351,7 @@ class MediaBrowser:
 
     def _make_pin_item(self, media_id: str, media_type: str, title: str) -> BrowseMediaItem:
         """Build the pin/unpin entry shown at the top of pinnable directories."""
-        pinned = favorites.is_favorite(
-            self._device.device_config.favorites, media_id, media_type
-        )
+        pinned = favorites.is_favorite(self._device.device_config.favorites, media_id, media_type)
         label_key = "📍 Unpin this folder" if pinned else "📍 Pin this folder"
         return BrowseMediaItem(
             title=self.get_localized(label_key),
@@ -369,9 +363,7 @@ class MediaBrowser:
             items=[],
         )
 
-    def _maybe_inject_pin_item(
-        self, item: BrowseMediaItem, media_id: str | None, media_type: str | None
-    ) -> None:
+    def _maybe_inject_pin_item(self, item: BrowseMediaItem, media_id: str | None, media_type: str | None) -> None:
         """Insert the pin/unpin item at the top of ``item.items`` if applicable."""
         if not media_id or not item or not item.items:
             return
@@ -379,9 +371,11 @@ class MediaBrowser:
             return
         title = item.title or media_id
         # Skip if already injected (defensive against double calls)
-        if item.items and isinstance(item.items[0], BrowseMediaItem) and (
-            item.items[0].media_id or ""
-        ).startswith(favorites.FAVORITES_TOGGLE_PREFIX):
+        if (
+            item.items
+            and isinstance(item.items[0], BrowseMediaItem)
+            and (item.items[0].media_id or "").startswith(favorites.FAVORITES_TOGGLE_PREFIX)
+        ):
             return
         # Insert just AFTER an existing back item if present, otherwise at top
         insert_at = 1 if item.items and item.items[0].title in ("..", self.get_localized("..")) else 0
@@ -1078,9 +1072,7 @@ class MediaBrowser:
                         if favorites.is_favorite(cfg.favorites, media_id, media_type or "addondir"):
                             if favorites.mark_broken(cfg.favorites, media_id, media_type or "addondir", True):
                                 self._persist_favorites()
-                            item.items.append(
-                                self._make_pin_item(media_id, media_type or "addondir", media_id)
-                            )
+                            item.items.append(self._make_pin_item(media_id, media_type or "addondir", media_id))
                     if data:
                         for file in data.get("files", []) or []:
                             sub = self.get_item_from_file(file, "addondir", extract_thumbnail=False)

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -346,18 +346,6 @@ class Kodi:
             raise ValueError(f"Invalid method: {method}")
         return await getattr(self._server, method)(*args)
 
-    async def get_favourites(self, properties=None):
-        """Retrieve all Kodi favourites.
-
-        :param properties: list of properties to retrieve (path, thumbnail,
-            window, windowparameter).  Defaults to all properties when None.
-        :returns: dict with ``favourites`` list and ``limits``.
-        """
-        params: dict = {}
-        if properties is not None:
-            params["properties"] = properties
-        return await self._server.Favourites.GetFavourites(**params)
-
     async def _add_item_to_playlist(self, item):
         await self._server.Playlist.Add(**{"playlistid": 0, "item": item})
 
@@ -521,7 +509,7 @@ class Kodi:
     async def add_favourites(
         self,
         title: str,
-        type: Literal["media", "window", "script", "androidapp", "unknown"],
+        fav_type: Literal["media", "window", "script", "androidapp", "unknown"],
         path: str | None = None,
         window: str | None = None,
         windowparameter: str | None = None,
@@ -530,7 +518,7 @@ class Kodi:
         """Add a user favourites."""
         return await self._server.Favourites.AddFavourites(
             **_build_query(
-                title=title, type=type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail
+                title=title, type=fav_type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail
             )
         )
 

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -8,6 +8,7 @@ Implementation of a Kodi interface.
 import asyncio
 import logging
 import urllib.parse
+from typing import Literal, Any
 from urllib.parse import quote
 
 import aiohttp
@@ -498,6 +499,28 @@ class Kodi:
             await self._server.Player.SetSubtitle(
                 **{"playerid": players[0]["playerid"], "subtitle": stream_index, "enable": enable}
             )
+
+    async def get_favourites(self) -> list[dict[str, Any]]:
+        """Get user favourites."""
+        return await self._server.Favourites.GetFavourites(
+            **_build_query(properties=["window", "windowparameter", "thumbnail", "path"])
+        )
+
+    async def add_favourites(
+        self,
+        title: str,
+        type: Literal["media", "window", "script", "androidapp", "unknown"],
+        path: str | None = None,
+        window: str | None = None,
+        windowparameter: str | None = None,
+        thumbnail: str | None = None,
+    ) -> str:
+        """Add a user favourites."""
+        return await self._server.Favourites.AddFavourites(
+            **_build_query(
+                title=title, type=type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail
+            )
+        )
 
 
 def _build_query(**kwargs):

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -500,8 +500,13 @@ class Kodi:
                 **{"playerid": players[0]["playerid"], "subtitle": stream_index, "enable": enable}
             )
 
-    async def get_favourites(self) -> list[dict[str, Any]]:
-        """Get user favourites."""
+    async def get_favourites(self) -> dict[str, Any]:
+        """Get user favourites.
+
+        Returns the raw JSON-RPC result with ``favourites`` array and
+        ``limits`` object.  Use ``favorites.get_kodi_favourites`` for a
+        validated, extracted list.
+        """
         return await self._server.Favourites.GetFavourites(
             **_build_query(properties=["window", "windowparameter", "thumbnail", "path"])
         )

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -518,8 +518,11 @@ class Kodi:
         """Add a user favourites."""
         return await self._server.Favourites.AddFavourites(
             **_build_query(
-                title=title, type=fav_type, path=path,
-                window=window, windowparameter=windowparameter,
+                title=title,
+                type=fav_type,
+                path=path,
+                window=window,
+                windowparameter=windowparameter,
                 thumbnail=thumbnail,
             )
         )

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -8,7 +8,7 @@ Implementation of a Kodi interface.
 import asyncio
 import logging
 import urllib.parse
-from typing import Literal, Any
+from typing import Any, Literal
 from urllib.parse import quote
 
 import aiohttp

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -518,7 +518,9 @@ class Kodi:
         """Add a user favourites."""
         return await self._server.Favourites.AddFavourites(
             **_build_query(
-                title=title, type=fav_type, path=path, window=window, windowparameter=windowparameter, thumbnail=thumbnail
+                title=title, type=fav_type, path=path,
+                window=window, windowparameter=windowparameter,
+                thumbnail=thumbnail,
             )
         )
 

--- a/src/pykodi/kodi.py
+++ b/src/pykodi/kodi.py
@@ -345,6 +345,18 @@ class Kodi:
             raise ValueError(f"Invalid method: {method}")
         return await getattr(self._server, method)(*args)
 
+    async def get_favourites(self, properties=None):
+        """Retrieve all Kodi favourites.
+
+        :param properties: list of properties to retrieve (path, thumbnail,
+            window, windowparameter).  Defaults to all properties when None.
+        :returns: dict with ``favourites`` list and ``limits``.
+        """
+        params: dict = {}
+        if properties is not None:
+            params["properties"] = properties
+        return await self._server.Favourites.GetFavourites(**params)
+
     async def _add_item_to_playlist(self, item):
         await self._server.Playlist.Add(**{"playlistid": 0, "item": item})
 

--- a/src/setup_fields.py
+++ b/src/setup_fields.py
@@ -87,6 +87,7 @@ KODI_BROWSING_CATEGORIES = [
     {"id": "kodi://addons", "label": {"en": "Addons", "fr": "Extensions", "de": "Addons"}},
     {"id": "kodi://addons/video", "label": {"en": "Video addons", "fr": "Extensions vidéo", "de": "Video-Addons"}},
     {"id": "kodi://addons/audio", "label": {"en": "Music addons", "fr": "Extensions musique", "de": "Musik-Addons"}},
+    {"id": "kodi://favorites", "label": {"en": "Favorites", "fr": "Favoris", "de": "Favoriten"}},
 ]
 
 SETUP_FIELDS = [
@@ -142,6 +143,15 @@ SETUP_FIELDS = [
         "label": {
             "en": "Default browsing media category",
             "fr": "Catégorie de navigation par défaut",
+        },
+    },
+    {
+        "field": {"checkbox": {"value": False}},
+        "id": "favorites_in_root",
+        "label": {
+            "en": "Show favorites directly in the browse root",
+            "fr": "Afficher les favoris directement dans la racine de navigation",
+            "de": "Favoriten direkt im Browse-Hauptmenü anzeigen",
         },
     },
     {

--- a/src/setup_flow.py
+++ b/src/setup_flow.py
@@ -400,6 +400,9 @@ class SetupFlow:
                         user_input.settings, "browse_media_root", self._reconfigured_device.browse_media_root
                     )
                     set_setup_field(
+                        user_input.settings, "favorites_in_root", self._reconfigured_device.favorites_in_root
+                    )
+                    set_setup_field(
                         user_input.settings, "browsing_video_sort", self._reconfigured_device.browsing_video_sort
                     )
                     set_setup_field(
@@ -607,6 +610,12 @@ class SetupFlow:
         sensor_include_device_name = msg.input_values.get("sensor_include_device_name", "false") == "true"
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
+        raw_favorites_in_root = msg.input_values.get("favorites_in_root", False)
+        favorites_in_root = (
+            raw_favorites_in_root
+            if isinstance(raw_favorites_in_root, bool)
+            else str(raw_favorites_in_root).lower() == "true"
+        )
 
         try:
             sensor_audio_stream_config = int(
@@ -709,6 +718,7 @@ class SetupFlow:
                 browsing_album_sort=browsing_album_sort,
                 browsing_files_sort=browsing_files_sort,
                 browse_media_root=browse_media_root,
+                favorites_in_root=favorites_in_root,
             )
         )  # triggers SonyLG TV instance creation
         config.devices.store()
@@ -751,6 +761,12 @@ class SetupFlow:
         sensor_include_device_name = msg.input_values.get("sensor_include_device_name", "false") == "true"
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
+        raw_favorites_in_root = msg.input_values.get("favorites_in_root", False)
+        favorites_in_root = (
+            raw_favorites_in_root
+            if isinstance(raw_favorites_in_root, bool)
+            else str(raw_favorites_in_root).lower() == "true"
+        )
         name = msg.input_values["name"]
         try:
             sensor_audio_stream_config = int(
@@ -788,6 +804,7 @@ class SetupFlow:
         self._reconfigured_device.browsing_album_sort = browsing_album_sort
         self._reconfigured_device.browsing_files_sort = browsing_files_sort
         self._reconfigured_device.browse_media_root = browse_media_root
+        self._reconfigured_device.favorites_in_root = favorites_in_root
 
         config.devices.add_or_update(self._reconfigured_device)  # triggers ATV instance update
         await asyncio.sleep(1)

--- a/src/setup_flow.py
+++ b/src/setup_flow.py
@@ -610,12 +610,7 @@ class SetupFlow:
         sensor_include_device_name = msg.input_values.get("sensor_include_device_name", "false") == "true"
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
-        raw_favorites_in_root = msg.input_values.get("favorites_in_root", False)
-        favorites_in_root = (
-            raw_favorites_in_root
-            if isinstance(raw_favorites_in_root, bool)
-            else str(raw_favorites_in_root).lower() == "true"
-        )
+        favorites_in_root = msg.input_values.get("favorites_in_root", "false") == "true"
 
         try:
             sensor_audio_stream_config = int(
@@ -761,12 +756,7 @@ class SetupFlow:
         sensor_include_device_name = msg.input_values.get("sensor_include_device_name", "false") == "true"
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
-        raw_favorites_in_root = msg.input_values.get("favorites_in_root", False)
-        favorites_in_root = (
-            raw_favorites_in_root
-            if isinstance(raw_favorites_in_root, bool)
-            else str(raw_favorites_in_root).lower() == "true"
-        )
+        favorites_in_root = msg.input_values.get("favorites_in_root", "false") == "true"
         name = msg.input_values["name"]
         try:
             sensor_audio_stream_config = int(

--- a/src/translations.py
+++ b/src/translations.py
@@ -34,25 +34,4 @@ TRANSLATIONS = {
     "Now": {"fr": "Maintenant", "de": "Jetzt"},
     "Next": {"fr": "Ensuite", "de": "Danach"},
     "Favorites": {"fr": "Favoris", "de": "Favoriten"},
-    "Manage favorites": {"fr": "Gérer les favoris", "de": "Favoriten verwalten"},
-    "Cleanup broken favorites": {
-        "fr": "Nettoyer les favoris cassés",
-        "de": "Defekte Favoriten aufräumen",
-    },
-    "Removed {0} broken favorites": {
-        "fr": "{0} favoris cassés supprimés",
-        "de": "{0} defekte Favoriten entfernt",
-    },
-    "Pinned": {"fr": "Épinglé", "de": "Angepinnt"},
-    "Unpinned": {"fr": "Désépinglé", "de": "Entpinnt"},
-    "Unpin": {"fr": "Désépingler", "de": "Entpinnen"},
-    "Invalid favorite": {"fr": "Favori invalide", "de": "Ungültiger Favorit"},
-    "📍 Pin this folder": {
-        "fr": "📍 Épingler ce dossier",
-        "de": "📍 Diesen Ordner anpinnen",
-    },
-    "📍 Unpin this folder": {
-        "fr": "📍 Désépingler ce dossier",
-        "de": "📍 Diesen Ordner entpinnen",
-    },
 }

--- a/src/translations.py
+++ b/src/translations.py
@@ -33,4 +33,26 @@ TRANSLATIONS = {
     "Music addons": {"fr": "Extensions musique", "de": "Musik-Addons"},
     "Now": {"fr": "Maintenant", "de": "Jetzt"},
     "Next": {"fr": "Ensuite", "de": "Danach"},
+    "Favorites": {"fr": "Favoris", "de": "Favoriten"},
+    "Manage favorites": {"fr": "Gérer les favoris", "de": "Favoriten verwalten"},
+    "Cleanup broken favorites": {
+        "fr": "Nettoyer les favoris cassés",
+        "de": "Defekte Favoriten aufräumen",
+    },
+    "Removed {0} broken favorites": {
+        "fr": "{0} favoris cassés supprimés",
+        "de": "{0} defekte Favoriten entfernt",
+    },
+    "Pinned": {"fr": "Épinglé", "de": "Angepinnt"},
+    "Unpinned": {"fr": "Désépinglé", "de": "Entpinnt"},
+    "Unpin": {"fr": "Désépingler", "de": "Entpinnen"},
+    "Invalid favorite": {"fr": "Favori invalide", "de": "Ungültiger Favorit"},
+    "📍 Pin this folder": {
+        "fr": "📍 Épingler ce dossier",
+        "de": "📍 Diesen Ordner anpinnen",
+    },
+    "📍 Unpin this folder": {
+        "fr": "📍 Désépingler ce dossier",
+        "de": "📍 Diesen Ordner entpinnen",
+    },
 }

--- a/test_driver.py
+++ b/test_driver.py
@@ -1545,7 +1545,7 @@ class RemoteInterface(tk.Tk):
                             self._setup_data.mapping[field_id] = text_area
                             self._setup_data.mapping_type[field_id] = "textarea"
                         elif checkbox := field.get("checkbox"):
-                            var = tk.IntVar(value=1 if checkbox.get("value", "false") == "true" else 0)
+                            var = tk.IntVar(value=1 if checkbox.get("value", False) else 0)
                             checkbox_button = tk.Checkbutton(
                                 self._setup_data.window, variable=var, onvalue=1, offvalue=0
                             )


### PR DESCRIPTION
I don't know the exact rules of : path + window + windowparameter

This fix just covers the browsing of a video folder from the favourites. This will need to be tuned to cover other categories