### PR TITLE
Feature/kodi favorites and livetv improvements

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -74,6 +74,8 @@ class KodiConfigDevice:
     browse_media_root: str = field(default="")
     # Show Kodi favourites flat in the browse root in addition to the "Favourites" entry
     favorites_in_root: bool = field(default=False)
+    # Show PVR channel groups when browsing Live TV / Radio (otherwise jump straight to channels)
+    show_channel_groups: bool = field(default=True)
 
     # pylint: disable=R0801
     def __post_init__(self):

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -11,6 +11,8 @@ endpoint so the media browser can display the user's Kodi-native favourites.
 from __future__ import annotations
 
 import logging
+import re
+import urllib.parse
 from typing import Any
 
 from const import IKodiDevice
@@ -21,6 +23,72 @@ _LOG = logging.getLogger(__name__)
 FAVORITES_ROOT = "kodi://favorites"
 
 VALID_FAVOURITE_TYPES = frozenset({"media", "window", "script", "androidapp", "unknown"})
+
+# Kodi PVR favourite URL patterns, e.g.
+#   pvr://channels/tv/All%20channels@-1/
+#   pvr://channels/tv/My%20Group@7/
+#   pvr://channels/tv/My%20Group@7/12.pvr
+#   pvr://channels/radio/Stations@3/
+_PVR_GROUP_RE = re.compile(
+    r"^pvr://channels/(?P<ctype>tv|radio)/(?P<group>[^/]*?)@(?P<gid>-?\d+)/?(?P<rest>.*)$"
+)
+
+
+def rewrite_favorite_path(path: str) -> tuple[str, str | None, bool] | None:
+    """Translate a Kodi favourite *path* into the integration's internal media id.
+
+    Returns ``(media_id, media_type, can_play)`` when the path is recognised as a
+    PVR resource that the media browser knows how to render natively, or ``None``
+    when the favourite should be passed through unchanged (Kodi will resolve it
+    via ``Player.Open`` / ``Files.GetDirectory``).
+
+    *media_type* is set to a string the router in ``MediaBrowser.browse_media``
+    matches against (``channel`` for a single channel, ``channelgroup`` for a
+    group listing, ``None`` to keep the caller's default).
+    """
+    if not isinstance(path, str) or not path:
+        return None
+
+    pvr_match = _PVR_GROUP_RE.match(path)
+    if not pvr_match:
+        return None
+
+    ctype = pvr_match.group("ctype")
+    gid = int(pvr_match.group("gid"))
+    rest = pvr_match.group("rest") or ""
+
+    # Direct channel favourite: <groupurl>/<channelid>.pvr
+    channel_match = re.match(r"^(?P<channelid>\d+)\.pvr/?$", rest)
+    if channel_match:
+        channel_id = channel_match.group("channelid")
+        return channel_id, "channel", True
+
+    # "All channels" pseudo-group (gid == -1) → show the group list instead so
+    # the router does not crash on PVR.GetChannels(channelgroupid=-1).
+    if gid < 0:
+        return f"kodi://pvr/{ctype}", None, False
+
+    # Real channel group → use the existing kodi://pvr/<type>/<gid> handler.
+    return f"kodi://pvr/{ctype}/{gid}", "channelgroup", False
+
+
+def get_favorite_thumbnail(thumbnail: Any) -> str | None:
+    """Return a usable thumbnail URL from a Kodi favourite payload."""
+    if not isinstance(thumbnail, str) or not thumbnail:
+        return None
+    return thumbnail
+
+
+def decode_favorite_title(title: Any) -> str:
+    """Decode a percent-encoded favourite title (Kodi sometimes URL-encodes them)."""
+    if not isinstance(title, str):
+        return ""
+    if "%" in title:
+        try:
+            return urllib.parse.unquote(title)
+        except Exception:  # pylint: disable=W0718
+            return title
+    return title
 
 
 async def get_kodi_favourites(client: IKodiDevice) -> list[dict]:

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -29,9 +29,7 @@ VALID_FAVOURITE_TYPES = frozenset({"media", "window", "script", "androidapp", "u
 #   pvr://channels/tv/My%20Group@7/
 #   pvr://channels/tv/My%20Group@7/12.pvr
 #   pvr://channels/radio/Stations@3/
-_PVR_GROUP_RE = re.compile(
-    r"^pvr://channels/(?P<ctype>tv|radio)/(?P<group>[^/]*?)@(?P<gid>-?\d+)/?(?P<rest>.*)$"
-)
+_PVR_GROUP_RE = re.compile(r"^pvr://channels/(?P<ctype>tv|radio)/(?P<group>[^/]*?)@(?P<gid>-?\d+)/?(?P<rest>.*)$")
 
 
 def rewrite_favorite_path(path: str) -> tuple[str, str | None, bool] | None:

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -261,7 +261,7 @@ class MediaBrowser:
         favs = await favorites.get_kodi_favourites(self._device.client)
         sub: list[BrowseMediaItem] = [self.get_back_item("kodi://")]
         for fav in favs:
-            title = fav.get("title", "")
+            title = favorites.decode_favorite_title(fav.get("title", ""))
             window = fav.get("window")
             path = fav.get("path") or fav.get("windowparameter") or window or ""
             if not path:
@@ -275,6 +275,18 @@ class MediaBrowser:
                 case "pictures":
                     media_type = "kodi://sources/pictures"
 
+            can_play = True
+            media_class = MediaClass.DIRECTORY
+            rewrite = favorites.rewrite_favorite_path(path)
+            if rewrite is not None:
+                path, rewritten_type, can_play = rewrite
+                if rewritten_type is not None:
+                    media_type = rewritten_type
+                if rewritten_type == "channel":
+                    media_class = MediaClass.CHANNEL if hasattr(MediaClass, "CHANNEL") else MediaClass.VIDEO
+                elif rewritten_type == "channelgroup":
+                    media_class = MediaClass.DIRECTORY
+
             thumbnail: str | None = fav.get("thumbnail") or None
             if thumbnail:
                 thumbnail = self.get_artwork_url(thumbnail)
@@ -282,10 +294,10 @@ class MediaBrowser:
                 BrowseMediaItem(
                     title=title,
                     media_id=path,
-                    media_class=MediaClass.DIRECTORY,
+                    media_class=media_class,
                     media_type=media_type,
                     can_browse=True,
-                    can_play=True,
+                    can_play=can_play,
                     thumbnail=thumbnail,
                     items=[],
                 )
@@ -825,19 +837,37 @@ class MediaBrowser:
                         favs[: MAX_ROOT_FAVORITES - 1] if has_more_favorites else favs[:MAX_ROOT_FAVORITES]
                     )
                     for fav in visible_favorites:
-                        title = fav.get("title", "")
+                        title = favorites.decode_favorite_title(fav.get("title", ""))
                         path = fav.get("path") or fav.get("window") or fav.get("windowparameter") or ""
                         if not path:
                             continue
+
+                        media_type = MediaContentType.URL.value
+                        can_play = True
+                        media_class = MediaClass.DIRECTORY
+                        rewrite = favorites.rewrite_favorite_path(path)
+                        if rewrite is not None:
+                            path, rewritten_type, can_play = rewrite
+                            if rewritten_type is not None:
+                                media_type = rewritten_type
+                            if rewritten_type == "channel":
+                                media_class = (
+                                    MediaClass.CHANNEL if hasattr(MediaClass, "CHANNEL") else MediaClass.VIDEO
+                                )
+
+                        thumbnail = fav.get("thumbnail") or None
+                        if thumbnail:
+                            thumbnail = self.get_artwork_url(thumbnail)
+
                         root_favorites.append(
                             BrowseMediaItem(
                                 title=title,
                                 media_id=path,
-                                media_class=MediaClass.DIRECTORY,
-                                media_type=MediaContentType.URL.value,
+                                media_class=media_class,
+                                media_type=media_type,
                                 can_browse=True,
-                                can_play=True,
-                                thumbnail=fav.get("thumbnail") or None,
+                                can_play=can_play,
+                                thumbnail=thumbnail,
                                 items=[],
                             )
                         )

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -443,7 +443,7 @@ class MediaBrowser:
         if parent_id:
             media_id = parent_id + "/" + media_id
         return BrowseMediaItem(
-            title=movie.get("label", ""),
+            title=strip_kodi_formatting(movie.get("label", "")),
             subtitle=subtitle,
             media_id=media_id,
             media_class=MediaClass.MOVIE,
@@ -494,7 +494,7 @@ class MediaBrowser:
         subtitle = " ".join(subtitles)
 
         return BrowseMediaItem(
-            title=episode.get("label", ""),
+            title=strip_kodi_formatting(episode.get("label", "")),
             subtitle=subtitle,
             media_id=media_id,
             media_class=MediaClass.EPISODE,
@@ -513,7 +513,7 @@ class MediaBrowser:
         if parent_id:
             media_id = parent_id + "/" + media_id
         return BrowseMediaItem(
-            title=show.get("label", ""),
+            title=strip_kodi_formatting(show.get("label", "")),
             media_id=media_id,
             media_class=MediaClass.TV_SHOW,
             media_type=MediaContentType.TV_SHOW,
@@ -531,7 +531,7 @@ class MediaBrowser:
         if parent_id:
             media_id = parent_id + "/" + media_id
         return BrowseMediaItem(
-            title=season.get("label", ""),
+            title=strip_kodi_formatting(season.get("label", "")),
             media_id=media_id,
             media_class=MediaClass.SEASON,
             media_type=MediaContentType.SEASON,
@@ -565,14 +565,14 @@ class MediaBrowser:
         artist = get_element(album.get("artist", None))
         duration: int | None = album.get("albumduration", None)
         return BrowseMediaItem(
-            title=album.get("label", ""),
+            title=strip_kodi_formatting(album.get("label", "")),
             media_id=media_id,
             media_class=MediaClass.ALBUM,
             media_type=MediaContentType.ALBUM,
             can_browse=True,
             can_search=True,
             thumbnail=art,
-            album=album.get("label", None),
+            album=strip_kodi_formatting(album.get("label", "")) or None,
             artist=artist,
             duration=int(duration) if duration else None,
         )
@@ -587,7 +587,7 @@ class MediaBrowser:
         if parent_id:
             media_id = f"{parent_id}/{media_id}?artist={quote(artist_name)}"
         return BrowseMediaItem(
-            title=artist_name,
+            title=strip_kodi_formatting(artist_name),
             media_id=media_id,
             media_class=MediaClass.ARTIST,
             media_type=MediaContentType.ARTIST,
@@ -602,7 +602,7 @@ class MediaBrowser:
         art = get_artwork(song.get("art", None))
         if art:
             art = self.get_artwork_url(art)
-        title = song.get("label", "")
+        title = strip_kodi_formatting(song.get("label", ""))
         if song.get("track", None):
             title = f"{song.get('track', 0)}. {title}"
         if song.get("duration", None):
@@ -622,8 +622,8 @@ class MediaBrowser:
             can_search=True,
             can_play=True,
             thumbnail=art,
-            album=song.get("album", None),
-            artist=get_element(song.get("artist", None)),
+            album=strip_kodi_formatting(song.get("album", "")) or None,
+            artist=strip_kodi_formatting(get_element(song.get("artist", None)) or "") or None,
         )
 
     def get_item_from_genre(self, media_type: str, genre: dict[str, Any], parent_id: str) -> BrowseMediaItem:
@@ -635,7 +635,7 @@ class MediaBrowser:
         if parent_id:
             media_id = parent_id + "/" + media_id
         return BrowseMediaItem(
-            title=genre.get("label", ""),
+            title=strip_kodi_formatting(genre.get("label", "")),
             media_id=media_id,
             media_class=MediaClass.GENRE,
             media_type=media_type + "/" + quote(genre.get("label", "")),
@@ -648,7 +648,7 @@ class MediaBrowser:
         """Build item from a PVR channel group."""
         media_id = f"{parent_id}/{int(group.get('channelgroupid', 0))}"
         item = BrowseMediaItem(
-            title=group.get("label", ""),
+            title=strip_kodi_formatting(group.get("label", "")),
             media_id=media_id,
             media_class=MediaClass.DIRECTORY,
             media_type="channelgroup",
@@ -668,14 +668,14 @@ class MediaBrowser:
         broadcast_now = channel.get("broadcastnow") or {}
         broadcast_next = channel.get("broadcastnext") or {}
         if title_now := broadcast_now.get("title"):
-            subtitles.append(f"{self.get_localized('Now')}: {title_now}")
+            subtitles.append(f"{self.get_localized('Now')}: {strip_kodi_formatting(title_now)}")
         if title_next := broadcast_next.get("title"):
-            subtitles.append(f"{self.get_localized('Next')}: {title_next}")
+            subtitles.append(f"{self.get_localized('Next')}: {strip_kodi_formatting(title_next)}")
         subtitle: str | None = " | ".join(subtitles) if subtitles else None
         if subtitle is not None and len(subtitle) > 255:
             subtitle = subtitle[:252].rstrip() + "..."  # pylint: disable=E1136
         return BrowseMediaItem(
-            title=channel.get("label", ""),
+            title=strip_kodi_formatting(channel.get("label", "")),
             subtitle=subtitle,
             media_id=str(channel.get("channelid", 0)),
             media_class=MediaClass.CHANNEL if hasattr(MediaClass, "CHANNEL") else MediaClass.VIDEO,
@@ -767,7 +767,7 @@ class MediaBrowser:
             items.insert(
                 position,
                 BrowseMediaItem(
-                    title=f"{self.get_localized('Now playing')} " f"({playing.get('label', '')})",
+                    title=f"{self.get_localized('Now playing')} ({strip_kodi_formatting(playing.get('label', ''))})",
                     media_class=MediaClass.PLAYLIST,
                     media_type=MediaClass.PLAYLIST,
                     media_id="kodi://playing",
@@ -1594,9 +1594,9 @@ class MediaBrowser:
                             item.items.append(
                                 BrowseMediaItem(
                                     title=(
-                                        playlist_item.get("label", "")
+                                        strip_kodi_formatting(playlist_item.get("label", ""))
                                         if position != current_playlist.position or not tag_current
-                                        else f">> {playlist_item.get('label', '')} <<"
+                                        else f">> {strip_kodi_formatting(playlist_item.get('label', ''))} <<"
                                     ),
                                     media_class=MediaClass(media_type.value),
                                     media_type=MediaContentType.PLAYLIST,

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -1039,7 +1039,7 @@ class MediaBrowser:
                         item.items.append(self.get_back_item(entry.parent_id))
                     for media in data.get("files", []):
                         # Strip off extension file
-                        media["label"] = os.path.splitext(media.get("label"))[0]
+                        media["label"] = os.path.splitext(media.get("label") or "")[0]
                         media["filetype"] = "file"
                         item.items.append(self.get_item_from_file(media, media_id, extract_thumbnail=False))
                 elif entry.output == KodiObjectType.CHANNEL_GROUP:

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -851,9 +851,7 @@ class MediaBrowser:
                             if rewritten_type is not None:
                                 media_type = rewritten_type
                             if rewritten_type == "channel":
-                                media_class = (
-                                    MediaClass.CHANNEL if hasattr(MediaClass, "CHANNEL") else MediaClass.VIDEO
-                                )
+                                media_class = MediaClass.CHANNEL if hasattr(MediaClass, "CHANNEL") else MediaClass.VIDEO
 
                         thumbnail = fav.get("thumbnail") or None
                         if thumbnail:
@@ -1067,7 +1065,7 @@ class MediaBrowser:
                             _LOG.warning("PVR.GetChannels(all%s) failed: %s", channel_type, err)
                             chan_data = {}
                         for channel in chan_data.get("channels", []):
-                            item.items.append(self.get_item_from_channel(channel, media_id))
+                            item.items.append(self.get_item_from_channel(channel))
                     else:
                         for group in data.get("channelgroups", []):
                             item.items.append(self.get_item_from_channel_group(group, media_id))

--- a/src/media_browser.py
+++ b/src/media_browser.py
@@ -1045,8 +1045,32 @@ class MediaBrowser:
                 elif entry.output == KodiObjectType.CHANNEL_GROUP:
                     if self.add_back_entry(item.media_id, pagination_options):
                         item.items.append(self.get_back_item("kodi://pvr"))
-                    for group in data.get("channelgroups", []):
-                        item.items.append(self.get_item_from_channel_group(group, media_id))
+                    show_groups = getattr(self._device, "show_channel_groups", True)
+                    channel_type = (entry.arguments or {}).get("channeltype", "tv")
+                    if not show_groups:
+                        # Skip groups entirely and list every channel of the type
+                        try:
+                            chan_data = await self._device.server.PVR.GetChannels(
+                                channelgroupid=f"all{channel_type}",
+                                properties=[
+                                    "thumbnail",
+                                    "channeltype",
+                                    "broadcastnow",
+                                    "broadcastnext",
+                                    "channel",
+                                    "lastplayed",
+                                    "hidden",
+                                    "locked",
+                                ],
+                            )
+                        except Exception as err:  # pylint: disable=W0718
+                            _LOG.warning("PVR.GetChannels(all%s) failed: %s", channel_type, err)
+                            chan_data = {}
+                        for channel in chan_data.get("channels", []):
+                            item.items.append(self.get_item_from_channel(channel, media_id))
+                    else:
+                        for group in data.get("channelgroups", []):
+                            item.items.append(self.get_item_from_channel_group(group, media_id))
                 elif entry.output == KodiObjectType.CHANNEL:
                     if self.add_back_entry(item.media_id, pagination_options):
                         item.items.append(self.get_back_item(entry.parent_id or "kodi://pvr"))

--- a/src/setup_fields.py
+++ b/src/setup_fields.py
@@ -155,6 +155,15 @@ SETUP_FIELDS = [
         },
     },
     {
+        "field": {"checkbox": {"value": True}},
+        "id": "show_channel_groups",
+        "label": {
+            "en": "Show channel groups in Live TV / Radio",
+            "fr": "Afficher les groupes de chaînes dans la TV en direct / Radio",
+            "de": "Kanalgruppen in Live-TV / Radio anzeigen",
+        },
+    },
+    {
         "field": {
             "dropdown": {
                 "value": "title",

--- a/src/setup_flow.py
+++ b/src/setup_flow.py
@@ -403,6 +403,9 @@ class SetupFlow:
                         user_input.settings, "favorites_in_root", self._reconfigured_device.favorites_in_root
                     )
                     set_setup_field(
+                        user_input.settings, "show_channel_groups", self._reconfigured_device.show_channel_groups
+                    )
+                    set_setup_field(
                         user_input.settings, "browsing_video_sort", self._reconfigured_device.browsing_video_sort
                     )
                     set_setup_field(
@@ -611,6 +614,7 @@ class SetupFlow:
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
         favorites_in_root = msg.input_values.get("favorites_in_root", "false") == "true"
+        show_channel_groups = msg.input_values.get("show_channel_groups", "true") == "true"
 
         try:
             sensor_audio_stream_config = int(
@@ -714,6 +718,7 @@ class SetupFlow:
                 browsing_files_sort=browsing_files_sort,
                 browse_media_root=browse_media_root,
                 favorites_in_root=favorites_in_root,
+                show_channel_groups=show_channel_groups,
             )
         )  # triggers SonyLG TV instance creation
         config.devices.store()
@@ -757,6 +762,7 @@ class SetupFlow:
         power_off_command = msg.input_values.get("power_off_command", next(iter(KODI_POWEROFF_COMMANDS)))
         browse_media_root = msg.input_values.get("browse_media_root", "")
         favorites_in_root = msg.input_values.get("favorites_in_root", "false") == "true"
+        show_channel_groups = msg.input_values.get("show_channel_groups", "true") == "true"
         name = msg.input_values["name"]
         try:
             sensor_audio_stream_config = int(
@@ -795,6 +801,7 @@ class SetupFlow:
         self._reconfigured_device.browsing_files_sort = browsing_files_sort
         self._reconfigured_device.browse_media_root = browse_media_root
         self._reconfigured_device.favorites_in_root = favorites_in_root
+        self._reconfigured_device.show_channel_groups = show_channel_groups
 
         config.devices.add_or_update(self._reconfigured_device)  # triggers ATV instance update
         await asyncio.sleep(1)


### PR DESCRIPTION
This pull request introduces improvements to how Kodi favorites and media items are handled, especially around Live TV/Radio channel groups, and ensures better display of media titles by stripping Kodi-specific formatting and decoding percent-encoded titles. It also adds a new configuration option to control the display of channel groups in the media browser.

**Enhancements to Kodi favorites and channel groups:**

- Added a new configuration option `show_channel_groups` (default: true) to allow users to choose whether to display channel groups in Live TV/Radio, or jump directly to channels. This is reflected in both the configuration schema and device logic. [[1]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R77-R78) [[2]](diffhunk://#diff-556771ff535ef83e5e181307d6cc32ac9525943bd6a95e347971ca28094322d2R157-R165) [[3]](diffhunk://#diff-8e1220a8ef23f2baf4b94646064fb49336d1115f00e74774b042258d399edb33R405-R407)
- Implemented `rewrite_favorite_path` in `favorites.py` to translate Kodi PVR favorite URLs into internal media IDs, allowing the media browser to natively render PVR favorites and improving integration with channel and channel group navigation.
- Updated the media browser logic to use the new `show_channel_groups` setting: when disabled, channel groups are skipped and all channels are listed directly.

**Improvements to media title handling:**

- Introduced `strip_kodi_formatting` and `decode_favorite_title` to clean up media item and favorite titles, removing Kodi-specific formatting and decoding percent-encoded titles for better readability throughout the UI. [[1]](diffhunk://#diff-47bfde972a1e9f027a3dfce6764a7042edd7d523c4890c7f0fb53fc3345e164dR27-R92) [[2]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L434-R446) [[3]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L485-R497) [[4]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L504-R516) [[5]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L522-R534) [[6]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L556-R575) [[7]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L578-R590) [[8]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L593-R605) [[9]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L613-R626) [[10]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L626-R638) [[11]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L639-R651) [[12]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L659-R678) [[13]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L758-R770) [[14]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L1543-R1599)

**General improvements and bug fixes:**

- Ensured correct handling of media item labels (e.g., removing file extensions safely) and improved thumbnail handling for favorites. [[1]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L1012-R1071) [[2]](diffhunk://#diff-47bfde972a1e9f027a3dfce6764a7042edd7d523c4890c7f0fb53fc3345e164dR27-R92)
- Updated the construction of `BrowseMediaItem` objects to use the new cleaned-up titles and to correctly set media class and type based on rewritten favorite paths. [[1]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758R278-R300) [[2]](diffhunk://#diff-9f54b99764cf8bf0be84c41d85cf9bff7b0d4270ec61a2b8219fd3cc2d7eb758L828-R870)

These changes make the integration more robust, user-friendly, and configurable, especially for users of Kodi's Live TV and Radio features.